### PR TITLE
Fix typo in doc: wrong method name

### DIFF
--- a/doc/api/admin.rst
+++ b/doc/api/admin.rst
@@ -8,7 +8,7 @@ You can create a new repository like this:
 
 .. code-block:: php
 
-    $repository = Gitonomy\Git\Admin::create('/path/to/folder');
+    $repository = Gitonomy\Git\Admin::init('/path/to/folder');
     // Folder /path/to/folder contains git repository files: objects, HEAD...
 
 By default, repository will be a bare repository. If you want to create a
@@ -16,5 +16,5 @@ repository with a working directory, pass ``false`` as second argument:
 
 .. code-block:: php
 
-    $repository = Gitonomy\Git\Admin::create('/path/to/folder', false);
+    $repository = Gitonomy\Git\Admin::init('/path/to/folder', false);
     // Folder /path/to/folder contains .git folder


### PR DESCRIPTION
According to https://github.com/gitonomy/gitlib/blob/master/src/Gitonomy/Git/Admin.php#L34, there is a typo in the doc :)
