### PR TITLE
Fixes the process builder for bare repositories with no working dir

### DIFF
--- a/src/Gitonomy/Git/Repository.php
+++ b/src/Gitonomy/Git/Repository.php
@@ -376,7 +376,14 @@ class Repository
      */
     protected function getProcess($command, $args = array())
     {
-        $base = array('git', '--git-dir', $this->gitDir, '--work-tree', $this->workingDir, $command);
+        $base = array('git', '--git-dir', $this->gitDir);
+
+        if ($this->workingDir) {
+            $base = array_merge($base, array('--work-tree', $this->workingDir));;
+        }
+
+        $base[] = $command;
+        
         $builder = new ProcessBuilder(array_merge($base, $args));
 
         return $builder->getProcess();


### PR DESCRIPTION
The --work-dir can not accept an empty string as of this commit
https://github.com/git/git/commit/3efe5d1d32fde899b23ebbb1fde499a0897e1c4e
(or maybe
https://github.com/git/git/commit/a0601dc11fab5b4525a348b2ad6c9bb92529a281,
I'm not very good at reading git's source code)
