### PR TITLE
Added type to tree entry object

### DIFF
--- a/src/Gitonomy/Git/Tree.php
+++ b/src/Gitonomy/Git/Tree.php
@@ -48,9 +48,9 @@ class Tree
         foreach ($parser->entries as $entry) {
             list($mode, $type, $hash, $name) = $entry;
             if ($type == 'blob') {
-                $this->entries[$name] = array($mode, $this->repository->getBlob($hash));
+                $this->entries[$name] = array($mode, $this->repository->getBlob($hash), $type);
             } else {
-                $this->entries[$name] = array($mode, $this->repository->getTree($hash));
+                $this->entries[$name] = array($mode, $this->repository->getTree($hash), $type);
             }
         }
 


### PR DESCRIPTION
Hey,

I needed quick access to determine easily if the tree entry object is another tree or a blob. So since this is already retrieved, just not returned I added it to the returned array.
