### PR TITLE
Added getShortname for reference

### DIFF
--- a/src/Gitonomy/Git/Reference.php
+++ b/src/Gitonomy/Git/Reference.php
@@ -67,6 +67,18 @@ abstract class Reference
     }
 
     /**
+     * Returns the shortname of the reference.
+     *
+     * Removes refs/heads and refs/tags/ from fullname
+     *
+     * @return string
+     */
+    public function getShortname()
+    {
+        return str_replace(array('refs/heads/', 'refs/tags/'), array('', ''), $this->fullname);
+    }
+
+    /**
      * Returns the commit associated to the reference.
      *
      * @return Gitonomy\Git\Commit


### PR DESCRIPTION
Hey,

I'm not sure if there is a better way to do this or if this covers all use cases, I needed a way to grab a short name from a reference the ref/heads/ and ref/tags/ is meaningless to the end user. So I made a quick function.

As I said before I'm not sure if this is the best way to do it, I'll leave that up to you guys to decide. I figured I'd at least start a discussion on it.
