### PR TITLE
Unset the HOME env before calling git binary

### DIFF
--- a/src/Gitonomy/Git/Repository.php
+++ b/src/Gitonomy/Git/Repository.php
@@ -434,6 +434,8 @@ class Repository
 
         $builder = new ProcessBuilder(array_merge($base, $args));
 
+        $builder->setEnv('HOME', null);
+
         return $builder->getProcess();
     }
 }


### PR DESCRIPTION
If we do no unset the env, git will use a potential
.gitconfig which can alter results
