### PR TITLE
Current output parsing is language depending

### DIFF
--- a/src/Gitonomy/Git/Repository.php
+++ b/src/Gitonomy/Git/Repository.php
@@ -412,7 +412,7 @@ class Repository
 
         $process->run();
 
-        if (!preg_match('/(\d+)\s+total$/', trim($process->getOutput()), $vars)) {
+        if (!preg_match('/^(\d+)\s/', trim($process->getOutput()), $vars)) {
             $message = sprintf("Unable to parse process output\ncommand: %s\noutput: %s", $process->getCommandLine(), $process->getOutput());
 
             if (null !== $this->logger) {


### PR DESCRIPTION
Currently the concrete output of `du` depends on the current systems locale. For example in German it is `1234 insgesamt`, which doesn't match the regular expression. The change tries to fetch the first number on that line and discards everything after.

What I currently ask myself: Does this work without problems with non-bare repositories too, or does that include the size of the checkout? Shouldn't be the output of `git count-objects -v` more reliable?
