### PR TITLE
chmod() isn't applicatable on symlinks

### DIFF
--- a/tests/Gitonomy/Git/Tests/AbstractTest.php
+++ b/tests/Gitonomy/Git/Tests/AbstractTest.php
@@ -109,7 +109,9 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
         $iterator = new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS);
         $iterator = new \RecursiveIteratorIterator($iterator, \RecursiveIteratorIterator::CHILD_FIRST);
         foreach ($iterator as $file) {
-            chmod($file, 0777);
+            if (!is_link($file)) {
+                chmod($file, 0777);
+            }
             if (is_dir($file)) {
                 rmdir($file);
             } else {


### PR DESCRIPTION
After merging https://github.com/gitonomy/gitlib/pull/41 the test trigger a warning on linux.

```
PHP Warning:  chmod(): No such file or directory in …/gitonomy/gitlib/tests/Gitonomy/Git/Tests/AbstractTest.php on line 106
```

PS: Ignore the branch name, it's a typo :wink:
