### PR TITLE
process timeouts and some refactoring

### DIFF
--- a/src/Gitonomy/Git/Repository.php
+++ b/src/Gitonomy/Git/Repository.php
@@ -89,6 +89,13 @@ class Repository
     protected $environmentVariables;
 
     /**
+     * Timeout that should be set for every running process.
+     *
+     * @var int
+     */
+    protected $processTimeout;
+
+    /**
      * Constructs a new repository.
      *
      * Available options are:
@@ -113,7 +120,8 @@ class Repository
             'debug'                 => true,
             'logger'                => null,
             'environment_variables' => array(),
-            'command'               => 'git'
+            'command'               => 'git',
+            'process_timeout'       => 3600
         ), $options);
 
         if (null !== $options['logger'] && ! $options['logger'] instanceof LoggerInterface) {
@@ -126,6 +134,7 @@ class Repository
         $this->objects              = array();
         $this->debug                = (bool) $options['debug'];
         $this->environmentVariables = $options['environment_variables'];
+        $this->processTimeout       = $options['process_timeout'];
         $this->command              = $options['command'];
 
         if (true === $this->debug && null !== $this->logger) {
@@ -615,6 +624,8 @@ class Repository
         $builder->inheritEnvironmentVariables(false);
         $process = $builder->getProcess();
         $process->setEnv($this->environmentVariables);
+        $process->setTimeout($this->processTimeout);
+        $process->setIdleTimeout($this->processTimeout);
 
         return $process;
     }

--- a/tests/Gitonomy/Git/Tests/AbstractTest.php
+++ b/tests/Gitonomy/Git/Tests/AbstractTest.php
@@ -131,6 +131,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
         return array(
             'command' => $command,
             'environment_variables' => $envs,
+            'process_timeout' => 60
         );
     }
 }


### PR DESCRIPTION
Hello!
My manager asked me to do some kind of report: calculate statistics about commits per user in our company. Github API has request limit that is not enough for me so I wrote small script to do all work on local computer (clone, iterate commits and so on). But I wanted to speed up my script by running it in many parallel processes (one per repository). And some of reposiitories were large. So, script was throwing exceptions that process exceeded timeout of 60 seconds.
When I tried to fix this I have found some copypaste, so I have done small refactoring.
All tests pass, so please have a look at this fix.
Thanks in advance.
