### PR TITLE
fixed warning when no parent found for a commit

### DIFF
--- a/src/Gitonomy/Git/Commit.php
+++ b/src/Gitonomy/Git/Commit.php
@@ -115,6 +115,7 @@ class Commit extends Revision
      */
     public function getParents()
     {
+        $result = array();
         foreach ($this->getData('parentHashes') as $parentHash) {
             $result[] = $this->repository->getCommit($parentHash);
         }


### PR DESCRIPTION
Sometimes a commit has no parents. 
This PR fixes a PHP notice when this happend:

```
Notice: Undefined variable: result in [...]/vendor/gitonomy/gitlib/src/Gitonomy/Git/Commit.php on line 122
```
