### PR TITLE
changed Admin::cloneRepository() scope to make it publicly usable

### DIFF
--- a/src/Gitonomy/Git/Admin.php
+++ b/src/Gitonomy/Git/Admin.php
@@ -129,7 +129,7 @@ class Admin
      *
      * @return Repository
      */
-    private static function cloneRepository($path, $url, array $args = array(), array $options = array())
+    public static function cloneRepository($path, $url, array $args = array(), array $options = array())
     {
         $process = static::getProcess('clone', array_merge(array('-q'), $args, array($url, $path)), $options);
 

--- a/tests/Gitonomy/Git/Tests/AdminTest.php
+++ b/tests/Gitonomy/Git/Tests/AdminTest.php
@@ -158,4 +158,21 @@ class AdminTest extends AbstractTest
 
         Admin::init($file, true, self::getOptions());
     }
+
+    public function testCloneRepository()
+    {
+        $newDir = self::createTempDir();
+        $args = array();
+
+        $new = Admin::cloneRepository($newDir, self::REPOSITORY_URL, $args, self::getOptions());
+        self::registerDeletion($new);
+
+        $newRefs = array_keys($new->getReferences()->getAll());
+
+        $this->assertTrue(in_array('refs/heads/master', $newRefs));
+        $this->assertTrue(in_array('refs/tags/0.1', $newRefs));
+
+        $this->assertEquals($newDir.'/.git', $new->getGitDir());
+        $this->assertEquals($newDir, $new->getWorkingDir());
+    }
 }


### PR DESCRIPTION
Hi,

Sometimes we need to pass some parameters that are not supported by gitlib  to `git clone` (like
--recursive, --depth).
Changing `Admin::cloneRepository()` scope to public make it possible to clone repository using specific parameters.

Thanks
