### PR TITLE
Implement WorkingCopy::getUntrackedFiles.

### DIFF
--- a/src/Gitonomy/Git/WorkingCopy.php
+++ b/src/Gitonomy/Git/WorkingCopy.php
@@ -43,7 +43,10 @@ class WorkingCopy
 
     public function getUntrackedFiles()
     {
-        return array();
+        $lines = explode("\0", $this->run('status', array('--porcelain', '--untracked-files=all', '-z')));
+        $lines = array_filter($lines, function($l) { return substr($l, 0, 3) === '?? '; });
+        $lines = array_map(function($l) { return substr($l, 3); }, $lines);
+        return $lines;
     }
 
     public function getDiffPending()

--- a/tests/Gitonomy/Git/Tests/WorkingCopyTest.php
+++ b/tests/Gitonomy/Git/Tests/WorkingCopyTest.php
@@ -99,4 +99,15 @@ class WorkingCopyTest extends AbstractTest
         $this->assertFalse($repository->isHeadAttached(), "HEAD is not attached");
         $this->assertTrue($repository->isHeadDetached(), "HEAD is detached");
     }
+
+    public function testGetUntracked()
+    {
+        $repository = self::createFoobarRepository(false);
+        $wc = $repository->getWorkingCopy();
+
+        $file = $repository->getWorkingDir() . '/untracked.txt';
+        file_put_contents($file, 'foo');
+
+        $this->assertContains('untracked.txt', $wc->getUntrackedFiles());
+    }
 }


### PR DESCRIPTION
Currently, the `WorkingCopy::getUntrackedFiles` method returns only a hardcoded empty array. This commit adds an implementation for this method that parses `git status` output and returns the list of untracked files as array.
