### PR TITLE
Composer fixes and updated the autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Gitonomy\\Git\\Tests\": "tests/Gitonomy/Git/Tests/"
+            "Gitonomy\\Git\\Tests\\": "tests/Gitonomy/Git/Tests/"
         }
     },
     "require": {


### PR DESCRIPTION
PSR-0 is deprecated, and we should also be autoloading our tests in `autoload-dev`. We can easily move to PSR-4 without moving any of the files thus retaining bc for any people still requiring files manually. Let me know if you're fine with actually just moving the files up 2 levels in the interest of keeping things clean.
