### PR TITLE
Added a 1.0-dev branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1-dev"
+            "dev-master": "1.0-dev"
         }
     },
 }


### PR DESCRIPTION
This means people can ask composer for `0.1.*@dev` and get the latest changes before you tag the next release.
