### PR TITLE
Encourage the use of stable version in installation instructions

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -15,6 +15,6 @@ Edit your ``composer.json`` file and add ``gitonomy/gitlib`` in section ``requir
 
     {
         "require": {
-            "gitonomy/gitlib": "dev-master"
+            "gitonomy/gitlib": "~0"
         }
     }


### PR DESCRIPTION
The current installation instructions advocates using dev-master.  It would probably be better to encourage the use of stable versions.

https://getcomposer.org/doc/01-basic-usage.md#next-significant-release-tilde-and-caret-operators-

https://getcomposer.org/doc/04-schema.md#minimum-stability
