### PR TITLE
Fix warning in windows when no PATH is available

### DIFF
--- a/src/Gitonomy/Git/Repository.php
+++ b/src/Gitonomy/Git/Repository.php
@@ -119,7 +119,7 @@ class Repository
             'working_dir'           => null,
             'debug'                 => true,
             'logger'                => null,
-            'environment_variables' => $is_windows ? array( 'PATH' => $_SERVER['PATH'] ) : array(),
+            'environment_variables' => $is_windows ? array( 'PATH' => getenv('PATH') ) : array(),
             'command'               => 'git',
             'process_timeout'       => 3600
         ), $options);


### PR DESCRIPTION
Fixes path warning in windows: #82 