### PR TITLE
support for --name-status log parsing

### DIFF
--- a/src/Gitonomy/Git/Commit.php
+++ b/src/Gitonomy/Git/Commit.php
@@ -124,6 +124,14 @@ class Commit extends Revision
     }
 
     /**
+     * @return array An array of file => status
+     */
+    public function getFiles()
+    {
+        return $this->getData('files');
+    }
+
+    /**
      * Returns the tree hash.
      *
      * @return string A SHA1 hash

--- a/src/Gitonomy/Git/Log.php
+++ b/src/Gitonomy/Git/Log.php
@@ -47,6 +47,11 @@ class Log implements \Countable, \IteratorAggregate
     protected $limit;
 
     /**
+     * @var array
+     */
+    protected $additional_args;
+
+    /**
      * Instanciates a git log object.
      *
      * @param Repository   $repository the repository where log occurs
@@ -55,7 +60,7 @@ class Log implements \Countable, \IteratorAggregate
      * @param int|null     $offset     start list from a given position
      * @param int|null     $limit      limit number of fetched elements
      */
-    public function __construct(Repository $repository, $revisions = null, $paths = null, $offset = null, $limit = null)
+    public function __construct(Repository $repository, $revisions = null, $paths = null, $offset = null, $limit = null, array $additional_args = null)
     {
         if (null !== $revisions && !$revisions instanceof RevisionList) {
             $revisions = new RevisionList($repository, $revisions);
@@ -74,6 +79,21 @@ class Log implements \Countable, \IteratorAggregate
         $this->paths      = $paths;
         $this->offset     = $offset;
         $this->limit      = $limit;
+        $this->additional_args = $additional_args;
+    }
+
+    public function setAdditionalArgs(array $additional_args){
+        $this->additional_args = $additional_args;
+    }
+
+    public function addAdditionalArgs(array $additional_args){
+        if(!isset($this->additional_args))
+            $this->additional_args = [];
+        $this->additional_args += $additional_args;
+    }
+
+    public function setNameStatus(){
+        $this->addAdditionalArgs(['--name-status']);
     }
 
     /**
@@ -156,6 +176,8 @@ class Log implements \Countable, \IteratorAggregate
     public function getCommits()
     {
         $args = array('--encoding='.StringHelper::getEncoding(), '--format=raw');
+        if($this->additional_args)
+            $args = array_merge($args, $this->additional_args);
 
         if (null !== $this->offset) {
             $args[] = '--skip='.((int) $this->offset);

--- a/src/Gitonomy/Git/Parser/LogParser.php
+++ b/src/Gitonomy/Git/Parser/LogParser.php
@@ -12,6 +12,8 @@
 
 namespace Gitonomy\Git\Parser;
 
+use Gitonomy\Git\Exception\RuntimeException;
+
 class LogParser extends CommitParser
 {
     public $log = array();
@@ -44,22 +46,57 @@ class LogParser extends CommitParser
             $this->consume('committer ');
             list($commit['committerName'], $commit['committerEmail'], $commit['committerDate']) = $this->consumeNameEmailDate();
             $commit['committerDate'] = $this->parseDate($commit['committerDate']);
-            $this->consumeNewLine();
-            $this->consumeNewLine();
 
             $message = '';
-            while ($this->expects('    ')) {
-                $message .= $this->consumeTo("\n")."\n";
-                $this->consumeNewLine();
+            $files = [];
+
+            //Is there a body?
+            $this->expects("\n"); //Last commit may not have trailing linebreaks
+            $this->expects("\n");
+
+            if($this->expects('    ')){
+                $message = $this->consumeMessage();
             }
 
-            if (!$this->isFinished()) {
-                $this->consumeNewLine();
+            $this->expects("\n");
+
+            if($this->lookAheadRegexp('/\w\t/')){
+                $files = $this->consumeFiles();
             }
+
+            $this->expects("\n");
 
             $commit['message'] = $message;
+            $commit['files'] = $files;
 
             $this->log[] = $commit;
         }
+    }
+
+    private function consumeMessage(){
+        $message = '';
+
+        do {
+            $message .= $this->consumeTo("\n") . "\n";
+            $this->consumeNewLine();
+        }while($this->expects('    '));
+
+        return $message;
+    }
+
+    private function consumeFiles(){
+        $files = [];
+
+        do{
+            $row = $this->consumeRegexp("/(.*?)(?:\n|$)/")[1];
+            if(!trim($row))
+                break;
+            if(strpos($row, "\t") === false)
+                throw new RuntimeException("Error in files: $row");
+            list($op, $file) = explode("\t", $row, 2);
+            $files[$file] = $op;
+        }while(true);
+
+        return $files;
     }
 }

--- a/src/Gitonomy/Git/Parser/ParserBase.php
+++ b/src/Gitonomy/Git/Parser/ParserBase.php
@@ -57,6 +57,15 @@ abstract class ParserBase
         return true;
     }
 
+    protected function lookAheadRegexp($regexp)
+    {
+        if (!preg_match($regexp.'A', $this->content, $vars, null, $this->cursor)) {
+            return false;
+        }
+
+        return true;
+    }
+
     protected function consumeShortHash()
     {
         if (!preg_match('/([A-Za-z0-9]{7,40})/A', $this->content, $vars, null, $this->cursor)) {


### PR DESCRIPTION
These are changes to support log --name-status command. 

Each commit in a log will contain list of changed files with their statuses. 

Usage:
        $log = $repo->getLog("master");
        $log->setNameStatus();
        $commits = $log->getCommits();

Each $commit will have $commit->getFiles() array($file => $status).