### PR TITLE
Adding process output to the exception description

### DIFF
--- a/src/Gitonomy/Git/Exception/ProcessException.php
+++ b/src/Gitonomy/Git/Exception/ProcessException.php
@@ -13,7 +13,9 @@ class ProcessException extends RuntimeException implements GitExceptionInterface
         parent::__construct("Error while running git command:\n".
             $process->getCommandLine()."\n".
             "\n".
-            $process->getErrorOutput()
+            $process->getErrorOutput()."\n".
+            "\n".
+            $process->getOutput()
         );
 
         $this->process = $process;


### PR DESCRIPTION
I tried to run the commit command without having properly adding the files to git and I got no output telling me what the problem was. I had to manually add this lines to see the error that came from git.

What do you think?