### PR TITLE
Fix GPG signed commits breaks parsing of commit messages

### DIFF
--- a/src/Gitonomy/Git/Parser/LogParser.php
+++ b/src/Gitonomy/Git/Parser/LogParser.php
@@ -43,6 +43,10 @@ class LogParser extends CommitParser
             $this->consume('committer ');
             list($commit['committerName'], $commit['committerEmail'], $commit['committerDate']) = $this->consumeNameEmailDate();
             $commit['committerDate'] = $this->parseDate($commit['committerDate']);
+
+            // will consume an GPG signed commit if there is one
+            $this->consumeGPGSignature();
+
             $this->consumeNewLine();
             $this->consumeNewLine();
 

--- a/src/Gitonomy/Git/Parser/ParserBase.php
+++ b/src/Gitonomy/Git/Parser/ParserBase.php
@@ -119,4 +119,19 @@ abstract class ParserBase
     {
         return $this->consume("\n");
     }
+
+    /**
+     * @return string
+     */
+    protected function consumeGPGSignature() {
+        $expected = "\ngpgsig ";
+        $length = strlen($expected);
+        $actual = substr($this->content, $this->cursor, $length);
+        if($actual != $expected) {
+            return '';
+        }
+        $this->cursor += $length;
+
+        return $this->consumeTo("\n\n");
+    }
 }

--- a/tests/Gitonomy/Git/Tests/AbstractTest.php
+++ b/tests/Gitonomy/Git/Tests/AbstractTest.php
@@ -24,6 +24,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
     const INITIAL_COMMIT = '74acd054c8ec873ae6be044041d3a85a4f890ba5';
     const MERGE_COMMIT = '2f5b9d0a4e6e7173d7816e417805709c708674f8';
     const ENCODING_COMMIT = '779420b9b936f18a0b6579e1499a85b14270802e';
+    const SIGNED_COMMIT = 'e1a83f16ed61ae3807e5652c7ef894692c813513';
 
     /**
      * Local clone of remote URL. Avoids network call on each test.

--- a/tests/Gitonomy/Git/Tests/PushReferenceTest.php
+++ b/tests/Gitonomy/Git/Tests/PushReferenceTest.php
@@ -56,6 +56,19 @@ class PushReferenceTest extends AbstractTest
     }
 
     /**
+     * This test ensures that GPG signed requests does not break the reading of commit logs.
+     *
+     * @dataProvider provideFoobar
+     */
+    public function testSignedLog($repository)
+    {
+        $ref = new PushReference($repository, 'foo', self::INITIAL_COMMIT, self::SIGNED_COMMIT);
+        $log = $ref->getLog()->getCommits();
+        $this->assertEquals(16, count($log), '16 commits in log');
+        $this->assertEquals('signed commit', $log[0]->getShortMessage(), 'Last commit is correct');
+    }
+
+    /**
      * @dataProvider provideFoobar
      */
     public function testLogWithExclude($repository)


### PR DESCRIPTION
If commits are [signed gpg](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work) they will break the parsing of the log message since it's expecting two newlines after the commiter date where in the case of a GPG signature is added:

Example commit:
```
commit e1a83f16ed61ae3807e5652c7ef894692c813513
tree 90908bdccbb0b9c42fdb6225d5aa47d7c66c3d22
parent 583811146f79f1bf6e167d54b276e21553512d1a
author Stig Lindqvist <stojg.lindqvist@gmail.com> 1461274840 +1200
committer Stig Lindqvist <stojg.lindqvist@gmail.com> 1461274840 +1200
gpgsig -----BEGIN PGP SIGNATURE-----
 Version: GnuPG v1

 iQEcBAABAgAGBQJXGUjZAAoJEF7kfUZDyWQIaUkIAMYsSKA2C3XOQ2x0Ig3zOF5Y
 DV1YlSWa2ILy/V49U55CWMP/Atbr1bKpREMI9y1T9tBwsMV1gtqYk+JwqyCntTjD
 iaFexti++AZv47YrQa4aBtW18hRJp/BFrLjhkGnydHLvK1QJ2EAhIuqwRYiMHS8m
 mX3ChT1Quk5yZFumpPduGqwdNVWDxCssNMA6MKjn/gBWV1PUbsZWN2a9I54v7xfR
 ujKvzqwsnkKhOC4+0sQM25sw0AHj2/pqhAmB7tW+mjcUBY911ym7f1SvAMdrdMHm
 S5AJ0RkrntFqUA1Ydc6om+zUCSB8ztuNbD4JK5YrqukEy2ooyehWs8qc1NNLVLQ=
 =4KdG
 -----END PGP SIGNATURE-----

    signed commit

```

This PR is the quick solution by consuming the GPGSig (if it exists) and then throw it away.

I added a test for this, but had to use my own [fork to create a signed commit](https://github.com/stojg/foobar/commit/e1a83f16ed61ae3807e5652c7ef894692c813513), so the tests will obviously fail unless the AbstractTest Repo is changed to `const REPOSITORY_URL = 'http://github.com/stojg/foobar.git';`

This should fix #108 