### PR TITLE
Fix GPG signed commits will break on reading full commit message

### DIFF
--- a/src/Gitonomy/Git/Parser/CommitParser.php
+++ b/src/Gitonomy/Git/Parser/CommitParser.php
@@ -45,6 +45,10 @@ class CommitParser extends ParserBase
         $this->consume('committer ');
         list($this->committerName, $this->committerEmail, $this->committerDate) = $this->consumeNameEmailDate();
         $this->committerDate = $this->parseDate($this->committerDate);
+
+        // will consume an GPG signed commit if there is one
+        $this->consumeGPGSignature();
+
         $this->consumeNewLine();
 
         $this->consumeNewLine();

--- a/tests/Gitonomy/Git/Tests/CommitTest.php
+++ b/tests/Gitonomy/Git/Tests/CommitTest.php
@@ -186,6 +186,18 @@ class CommitTest extends AbstractTest
     }
 
     /**
+     * This test ensures that GPG signed commits does not break the reading of a commit
+     * message.
+     *
+     * @dataProvider provideFoobar
+     */
+    public function testGetSignedMessage($repository)
+    {
+        $commit = $repository->getCommit(self::SIGNED_COMMIT);
+        $this->assertEquals('signed commit'."\n", $commit->getMessage());
+    }
+
+    /**
      * @dataProvider provideFoobar
      */
     public function testGetShortMessage($repository)


### PR DESCRIPTION
Ensure that we can get the full message when the commit has been GPG signed

Follow up on https://github.com/gitonomy/gitlib/pull/109 that only deals with the "log" part, this ensure that we can also return the message.