### PR TITLE
Configurable inheritance of environment variables by new process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /composer.lock
 /phpunit.xml
+.idea

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,12 @@
         }
     },
     "require": {
+        "php": ">=5.5.9",
         "symfony/process": "^2.3|^3.0"
     },
     "require-dev": {
-        "psr/log": "^1.0"
+        "psr/log": "^1.0",
+        "phpunit/phpunit": "^5.4"
     },
     "suggest": {
         "psr/log": "Add some log"

--- a/src/Gitonomy/Git/Repository.php
+++ b/src/Gitonomy/Git/Repository.php
@@ -16,7 +16,6 @@ use Gitonomy\Git\Exception\InvalidArgumentException;
 use Gitonomy\Git\Exception\ProcessException;
 use Gitonomy\Git\Exception\RuntimeException;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
 
 /**
@@ -94,6 +93,11 @@ class Repository
     protected $processTimeout;
 
     /**
+     * @var bool
+     */
+    private $inheritEnvironmentVariables;
+
+    /**
      * Constructs a new repository.
      *
      * Available options are:
@@ -121,6 +125,7 @@ class Repository
             'environment_variables' => $is_windows ? array('PATH' => getenv('path')) : array(),
             'command' => 'git',
             'process_timeout' => 3600,
+            'inherit_environment_variables' => false
         ), $options);
 
         if (null !== $options['logger'] && !$options['logger'] instanceof LoggerInterface) {
@@ -135,6 +140,7 @@ class Repository
         $this->environmentVariables = $options['environment_variables'];
         $this->processTimeout = $options['process_timeout'];
         $this->command = $options['command'];
+        $this->inheritEnvironmentVariables = $options['inherit_environment_variables'];
 
         if (true === $this->debug && null !== $this->logger) {
             $this->logger->debug(sprintf('Repository created (git dir: "%s", working dir: "%s")', $this->gitDir, $this->workingDir ?: 'none'));
@@ -619,7 +625,7 @@ class Repository
         $base[] = $command;
 
         $builder = new ProcessBuilder(array_merge($base, $args));
-        $builder->inheritEnvironmentVariables(false);
+        $builder->inheritEnvironmentVariables($this->inheritEnvironmentVariables);
         $process = $builder->getProcess();
         $process->setEnv($this->environmentVariables);
         $process->setTimeout($this->processTimeout);

--- a/tests/Gitonomy/Git/Tests/RepositoryTest.php
+++ b/tests/Gitonomy/Git/Tests/RepositoryTest.php
@@ -18,8 +18,9 @@ class RepositoryTest extends AbstractTest
 {
     /**
      * @dataProvider provideFoobar
+     * @param Repository $repository
      */
-    public function testGetBlob_WithExisting_Works($repository)
+    public function testGetBlob_WithExisting_Works(Repository $repository)
     {
         $blob = $repository->getCommit(self::LONGFILE_COMMIT)->getTree()->resolvePath('README.md');
 
@@ -29,8 +30,9 @@ class RepositoryTest extends AbstractTest
 
     /**
      * @dataProvider provideFoobar
+     * @param Repository $repository
      */
-    public function testGetSize($repository)
+    public function testGetSize(Repository $repository)
     {
         $size = $repository->getSize();
         $this->assertGreaterThan(70, $size, 'Repository is greater than 70KB');
@@ -47,22 +49,24 @@ class RepositoryTest extends AbstractTest
 
     /**
      * @dataProvider provideFoobar
+     * @param Repository $repository
      */
-    public function testGetDescription($repository)
+    public function testGetDescription(Repository $repository)
     {
         $this->assertSame("Unnamed repository; edit this file 'description' to name the repository.\n", $repository->getDescription());
     }
 
     /**
      * @dataProvider provideFoobar
+     * @param Repository $repository
      */
-    public function testLoggerOk($repository)
+    public function testLoggerOk(Repository $repository)
     {
         if (!interface_exists('Psr\Log\LoggerInterface')) {
             $this->markTestSkipped();
         }
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
         $logger
             ->expects($this->once())
             ->method('info')
@@ -79,15 +83,16 @@ class RepositoryTest extends AbstractTest
 
     /**
      * @dataProvider provideFoobar
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
+     * @param Repository $repository
      */
-    public function testLoggerNOk($repository)
+    public function testLoggerNOk(Repository $repository)
     {
         if (!interface_exists('Psr\Log\LoggerInterface')) {
             $this->markTestSkipped();
         }
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
         $logger
             ->expects($this->once())
             ->method('info')


### PR DESCRIPTION
Such initialisation of Repository class:

```
$repository = new Repository('path/to/repository', [
    'inherit_environment_variables' => true
]);
```

will create every new Process with with inherited global variables. It was imported when I wanted to integrated gitlib with phing and executed tests on travis. When option was hardcoded as false, then previously defined author for commits was not inherited by process. By default value is still set to false.

Change-log:
- min php version was added to composer.json (based on symfony/process)
- phpunit was added to composer.json as dev dependency
- usage of deprecated method \PHPUnit_Test_Case::getMock in RepositoryTest was replaced with \PHPUnit_Test_Case::getMockBuilder
- Repository class was extended with new property - inheritEnvironmentVariables that allows to create new process that inherits env vars (previously false value was hardcoded)
- .idea folder was added to .gitignore (PHPStorm internal files)
