### PR TITLE
Better directory existence check to avoid empty paths in exception

### DIFF
--- a/src/Gitonomy/Git/Repository.php
+++ b/src/Gitonomy/Git/Repository.php
@@ -149,16 +149,18 @@ class Repository
      */
     private function initDir($gitDir, $workingDir = null)
     {
-        $gitDir = realpath($gitDir);
+        $realGitDir = realpath($gitDir);
 
-        if (null === $workingDir && is_dir($gitDir.'/.git')) {
-            $workingDir = $gitDir;
-            $gitDir = $gitDir.'/.git';
-        } elseif (!is_dir($gitDir)) {
+        if (false === $realGitDir) {
             throw new InvalidArgumentException(sprintf('Directory "%s" does not exist or is not a directory', $gitDir));
+        } else if (!is_dir($realGitDir)) {
+            throw new InvalidArgumentException(sprintf('Directory "%s" does not exist or is not a directory', $realGitDir));
+        } elseif (null === $workingDir && is_dir($realGitDir.'/.git')) {
+            $workingDir = $realGitDir;
+            $realGitDir = $realGitDir.'/.git';
         }
 
-        $this->gitDir = $gitDir;
+        $this->gitDir = $realGitDir;
         $this->workingDir = $workingDir;
     }
 


### PR DESCRIPTION
When initializing a `Repository` instance, if the specified directory doesn't exist, the `realpath` call with return `false` and overwrite the old value, which prevents it from being displayed in the exception. This does the trick.

Also, I added PHPUnit as a development dependency and wrote a quick *how-to* to run tests.