### PR TITLE
Data in annotated tags

### DIFF
--- a/src/Gitonomy/Git/Parser/TagParser.php
+++ b/src/Gitonomy/Git/Parser/TagParser.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This file is part of Gitonomy.
+ *
+ * (c) Alexandre Salomé <alexandre.salome@gmail.com>
+ * (c) Julien DIDIER <genzo.wm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+namespace Gitonomy\Git\Parser;
+
+use Gitonomy\Git\Exception\RuntimeException;
+
+class TagParser extends ParserBase
+{
+    public $object;
+    public $type;
+    public $tag;
+    public $taggerName;
+    public $taggerEmail;
+    public $taggerDate;
+    public $gpgSignature;
+    public $message;
+
+    protected function doParse()
+    {
+        $this->consume('object ');
+        $this->object = $this->consumeHash();
+        $this->consumeNewLine();
+
+        $this->consume('type ');
+        $this->type = $this->consumeTo("\n");
+        $this->consumeNewLine();
+
+        $this->consume('tag ');
+        $this->tag = $this->consumeTo("\n");
+        $this->consumeNewLine();
+
+        $this->consume('tagger ');
+        list($this->taggerName, $this->taggerEmail, $this->taggerDate) = $this->consumeNameEmailDate();
+        $this->taggerDate = $this->parseDate($this->taggerDate);
+
+        $this->consumeNewLine();
+        $this->consumeNewLine();
+
+        try {
+            $this->message = $this->consumeTo("-----BEGIN PGP SIGNATURE-----");
+            $this->gpgSignature = $this->consumeGPGSignature();
+        } catch (RuntimeException $e) {
+            $this->message = $this->consumeAll();
+        }
+    }
+
+    protected function consumeGPGSignature()
+    {
+        $expected = "-----BEGIN PGP SIGNATURE-----";
+        $length = strlen($expected);
+        $actual = substr($this->content, $this->cursor, $length);
+        if ($actual != $expected) {
+            return '';
+        }
+        $this->cursor += $length;
+
+        return $this->consumeTo("-----END PGP SIGNATURE-----");
+    }
+
+    protected function consumeNameEmailDate()
+    {
+        if (!preg_match('/(([^\n]*) <([^\n]*)> (\d+ [+-]\d{4}))/A', $this->content, $vars, 0, $this->cursor)) {
+            throw new RuntimeException('Unable to parse name, email and date');
+        }
+
+        $this->cursor += strlen($vars[1]);
+
+        return array($vars[2], $vars[3], $vars[4]);
+    }
+
+    protected function parseDate($text)
+    {
+        $date = \DateTime::createFromFormat('U e O', $text.' UTC');
+
+        if (!$date instanceof \DateTime) {
+            throw new RuntimeException(sprintf('Unable to convert "%s" to datetime', $text));
+        }
+
+        return $date;
+    }
+}

--- a/tests/Gitonomy/Git/Tests/AbstractTest.php
+++ b/tests/Gitonomy/Git/Tests/AbstractTest.php
@@ -16,7 +16,7 @@ use Gitonomy\Git\Repository;
 
 abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 {
-    const REPOSITORY_URL = 'http://github.com/giorgioazzinnaro/foobar.git';
+    const REPOSITORY_URL = 'http://github.com/gitonomy/foobar.git';
 
     const LONGFILE_COMMIT = '4f17752acc9b7c54ba679291bf24cb7d354f0f4f';
     const BEFORE_LONGFILE_COMMIT = 'e0ec50e2af75fa35485513f60b2e658e245227e9';

--- a/tests/Gitonomy/Git/Tests/AbstractTest.php
+++ b/tests/Gitonomy/Git/Tests/AbstractTest.php
@@ -16,7 +16,7 @@ use Gitonomy\Git\Repository;
 
 abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 {
-    const REPOSITORY_URL = 'http://github.com/gitonomy/foobar.git';
+    const REPOSITORY_URL = 'http://github.com/giorgioazzinnaro/foobar.git';
 
     const LONGFILE_COMMIT = '4f17752acc9b7c54ba679291bf24cb7d354f0f4f';
     const BEFORE_LONGFILE_COMMIT = 'e0ec50e2af75fa35485513f60b2e658e245227e9';

--- a/tests/Gitonomy/Git/Tests/ReferenceTest.php
+++ b/tests/Gitonomy/Git/Tests/ReferenceTest.php
@@ -73,9 +73,29 @@ class ReferenceTest extends AbstractTest
         $tag = $repository->getReferences()->getTag('0.1');
 
         $this->assertTrue($tag instanceof Tag, 'Tag object is correct type');
+        $this->assertFalse($tag->isAnnotated(), 'Tag is not annotated');
 
         $this->assertEquals(self::LONGFILE_COMMIT, $tag->getCommitHash(), 'Commit hash is correct');
         $this->assertEquals(self::LONGFILE_COMMIT, $tag->getCommit()->getHash(), 'Commit hash is correct');
+    }
+
+    /**
+     * @dataProvider provideFoobar
+     */
+    public function testAnnotatedTag($repository)
+    {
+        $tag = $repository->getReferences()->getTag('annotated');
+
+        $this->assertTrue($tag instanceof Tag, 'Tag object is correct type');
+        $this->assertTrue($tag->isAnnotated(), 'Tag is annotated');
+        $this->assertFalse($tag->isSigned(), 'Tag is not signed');
+
+        $this->assertEquals('Bob', $tag->getTaggerName(), 'Tagger name is correct');
+        $this->assertEquals('bob@example.org', $tag->getTaggerEmail(), 'Tagger email is correct');
+        $this->assertEquals(1471428000, $tag->getTaggerDate()->getTimestamp(), 'Tag date is correct');
+
+        $this->assertEquals('heading', $tag->getSubjectMessage(), 'Message heading is correct');
+        $this->assertEquals("body\nbody", $tag->getBodyMessage(), 'Message body is correct');
     }
 
     /**

--- a/tests/Gitonomy/Git/Tests/ReferenceTest.php
+++ b/tests/Gitonomy/Git/Tests/ReferenceTest.php
@@ -90,8 +90,8 @@ class ReferenceTest extends AbstractTest
         $this->assertTrue($tag->isAnnotated(), 'Tag is annotated');
         $this->assertFalse($tag->isSigned(), 'Tag is not signed');
 
-        $this->assertEquals('Bob', $tag->getTaggerName(), 'Tagger name is correct');
-        $this->assertEquals('bob@example.org', $tag->getTaggerEmail(), 'Tagger email is correct');
+        $this->assertEquals('Graham Campbell', $tag->getTaggerName(), 'Tagger name is correct');
+        $this->assertEquals('graham@alt-three.com', $tag->getTaggerEmail(), 'Tagger email is correct');
         $this->assertEquals(1471428000, $tag->getTaggerDate()->getTimestamp(), 'Tag date is correct');
 
         $this->assertEquals('heading', $tag->getSubjectMessage(), 'Message heading is correct');


### PR DESCRIPTION
Similar to `Commit` and `CommitParser` to extract data from annotated tags.
Unit testing is available, but since it needs a properly annotated tag, `AbstractTest` is now pointing to my fork of `foobar` repo.

To add the same tag to the original repo:

``` bash
git config user.name "Bob"
git config user.email "bob@example.org"
GIT_COMMITTER_DATE="2016-08-17 12:00 +02:00" git tag -a annotated -m "heading
body
body"
```
