### PR TITLE
Add "refs/notes/gtm-data"

### DIFF
--- a/src/Gitonomy/Git/ReferenceBag.php
+++ b/src/Gitonomy/Git/ReferenceBag.php
@@ -367,6 +367,8 @@ class ReferenceBag implements \Countable, \IteratorAggregate
                 $this->references[$fullname] = $reference;
             } elseif (preg_match('#^refs/pull/(.*)$#', $fullname)) {
                 // Do nothing here
+            } elseif ($fullname === 'refs/notes/gtm-data') {
+                // Do nothing here
             } else {
                 throw new RuntimeException(sprintf('Unable to parse "%s"', $fullname));
             }


### PR DESCRIPTION
References for git time metrics (GTM)
```
[notes]
    rewriteref = refs/notes/gtm-data
```
results with Fatal error:
```
Uncaught Gitonomy\Git\Exception\RuntimeException:
Unable to parse "refs/notes/gtm-data" in
/vendor/gitonomy/gitlib/src/Gitonomy/Git/ReferenceBag.php
on line 371
```