### PR TITLE
Fix depreciation error from symfony/process

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "gitonomy/gitlib",
+    "name": "iwazaru/gitlib",
     "description": "Library for accessing git",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "iwazaru/gitlib",
+    "name": "gitonomy/gitlib",
     "description": "Library for accessing git",
     "license": "MIT",
     "authors": [

--- a/src/Gitonomy/Git/Repository.php
+++ b/src/Gitonomy/Git/Repository.php
@@ -621,7 +621,6 @@ class Repository
         $base[] = $command;
 
         $builder = new ProcessBuilder(array_merge($base, $args));
-        $builder->inheritEnvironmentVariables(false);
         $process = $builder->getProcess();
         $process->setEnv($this->environmentVariables);
         $process->setTimeout($this->processTimeout);


### PR DESCRIPTION
`inheritEnvironmentVariables` is deprecated since symfony/process 3.3. Documentation says :

> Not inheriting environment variables is deprecated since Symfony 3.3 and will always happen in 4.0.

So I removed the line `$builder->inheritEnvironmentVariables(false);` from Repository.php. Tests are still passing so I guess it's OK.