### PR TITLE
Fix return types in docblocks

### DIFF
--- a/src/Gitonomy/Git/Reference.php
+++ b/src/Gitonomy/Git/Reference.php
@@ -56,7 +56,7 @@ abstract class Reference extends Revision
     /**
      * Returns the commit associated to the reference.
      *
-     * @return Gitonomy\Git\Commit
+     * @return Commit
      */
     public function getCommit()
     {

--- a/src/Gitonomy/Git/ReferenceBag.php
+++ b/src/Gitonomy/Git/ReferenceBag.php
@@ -78,7 +78,7 @@ class ReferenceBag implements \Countable, \IteratorAggregate
      *
      * @param string $fullname Fullname of the reference (refs/heads/master, for example).
      *
-     * @return Gitonomy\Git\Reference A reference object.
+     * @return Reference A reference object.
      */
     public function get($fullname)
     {


### PR DESCRIPTION
[Phan](/phan/phan) rightfully complained about qualified class names which should have been fully qualified class names