### PR TITLE
Fixed issue with LogParser unable to parse commit with no message

### DIFF
--- a/src/Gitonomy/Git/Parser/LogParser.php
+++ b/src/Gitonomy/Git/Parser/LogParser.php
@@ -51,9 +51,16 @@ class LogParser extends CommitParser
             $this->consumeNewLine();
 
             $message = '';
-            while ($this->expects('    ')) {
-                $message .= $this->consumeTo("\n")."\n";
-                $this->consumeNewLine();
+            if ($this->expects('    ')) {
+                $this->cursor -= strlen('    ');
+
+                while ($this->expects('    ')) {
+                    $message .= $this->consumeTo("\n")."\n";
+                    $this->consumeNewLine();
+                }
+            }
+            else {
+                $this->cursor--;
             }
 
             if (!$this->isFinished()) {


### PR DESCRIPTION
There was an issue with LogParser unable to parse Git log when there is a commit with no message. The following exception would be thrown.

```
An uncaught Exception was encountered
Type: Gitonomy\Git\Exception\RuntimeException

Message: Expected " ", but got "c" (commit 896)

Filename: C:\Apache24\htdocs\apps\vendor\gitonomy\gitlib\src\Gitonomy\Git\Parser\ParserBase.php

Line Number: 111

Backtrace:

File: C:\Apache24\htdocs\apps\vendor\gitonomy\gitlib\src\Gitonomy\Git\Parser\ParserBase.php
Line: 120
Function: consume

File: C:\Apache24\htdocs\apps\vendor\gitonomy\gitlib\src\Gitonomy\Git\Parser\LogParser.php
Line: 60
Function: consumeNewLine

File: C:\Apache24\htdocs\apps\vendor\gitonomy\gitlib\src\Gitonomy\Git\Parser\ParserBase.php
Line: 30
Function: doParse

File: C:\Apache24\htdocs\apps\vendor\gitonomy\gitlib\src\Gitonomy\Git\Log.php
Line: 185
Function: parse

File: C:\Apache24\htdocs\apps\vendor\gitonomy\gitlib\src\Gitonomy\Git\Log.php
Line: 214
Function: getCommits

File: C:\Apache24\htdocs\apps\application\controllers\GitPackager.php
Line: 20
Function: getIterator

File: C:\Apache24\htdocs\apps\index.php
Line: 318
Function: require_once
```