### PR TITLE
Fix DateTime namespace in return annotations

### DIFF
--- a/src/Gitonomy/Git/Commit.php
+++ b/src/Gitonomy/Git/Commit.php
@@ -265,7 +265,7 @@ class Commit extends Revision
     /**
      * Returns the authoring date.
      *
-     * @return DateTime A time object
+     * @return \DateTime A time object
      */
     public function getAuthorDate()
     {
@@ -295,7 +295,7 @@ class Commit extends Revision
     /**
      * Returns the authoring date.
      *
-     * @return DateTime A time object
+     * @return \DateTime A time object
      */
     public function getCommitterDate()
     {


### PR DESCRIPTION
The DateTime class should be in the global namespace rather than relative to the current class