### PR TITLE
Test enhancement

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,7 @@
 
     <testsuites>
         <testsuite name="Test Suite">
-            <directory>tests/Gitonomy/Git/Tests</directory>
+            <directory suffix="Test.php">tests/Gitonomy/Git/Tests</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/Gitonomy/Git/Tests/AdminTest.php
+++ b/tests/Gitonomy/Git/Tests/AdminTest.php
@@ -20,12 +20,12 @@ class AdminTest extends AbstractTest
 {
     private $tmpDir;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->tmpDir = self::createTempDir();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->deleteDir(self::createTempDir());
     }
@@ -37,8 +37,8 @@ class AdminTest extends AbstractTest
         $objectDir = $this->tmpDir.'/objects';
 
         $this->assertTrue($repository->isBare(), 'Repository is bare');
-        $this->assertTrue(is_dir($objectDir), 'objects/ folder is present');
-        $this->assertTrue($repository instanceof Repository, 'Admin::init returns a repository');
+        $this->assertDirectoryExists($objectDir, 'objects/ folder is present');
+        $this->assertInstanceOf(Repository::class, $repository, 'Admin::init returns a repository');
         $this->assertEquals($this->tmpDir, $repository->getGitDir(), 'The folder passed as argument is git dir');
         $this->assertNull($repository->getWorkingDir(), 'No working dir in bare repository');
     }
@@ -50,8 +50,8 @@ class AdminTest extends AbstractTest
         $objectDir = $this->tmpDir.'/.git/objects';
 
         $this->assertFalse($repository->isBare(), 'Repository is not bare');
-        $this->assertTrue(is_dir($objectDir), 'objects/ folder is present');
-        $this->assertTrue($repository instanceof Repository, 'Admin::init returns a repository');
+        $this->assertDirectoryExists($objectDir, 'objects/ folder is present');
+        $this->assertInstanceOf(Repository::class, $repository, 'Admin::init returns a repository');
         $this->assertEquals($this->tmpDir.'/.git', $repository->getGitDir(), 'git dir as subfolder of argument');
         $this->assertEquals($this->tmpDir, $repository->getWorkingDir(), 'working dir present in bare repository');
     }
@@ -67,12 +67,12 @@ class AdminTest extends AbstractTest
 
         $newRefs = array_keys($new->getReferences()->getAll());
 
-        $this->assertTrue(in_array('refs/heads/master', $newRefs));
-        $this->assertTrue(in_array('refs/tags/0.1', $newRefs));
+        $this->assertContains('refs/heads/master', $newRefs);
+        $this->assertContains('refs/tags/0.1', $newRefs);
 
         if ($repository->isBare()) {
             $this->assertEquals($newDir, $new->getGitDir());
-            $this->assertTrue(in_array('refs/heads/new-feature', $newRefs));
+            $this->assertContains('refs/heads/new-feature', $newRefs);
         } else {
             $this->assertEquals($newDir.'/.git', $new->getGitDir());
             $this->assertEquals($newDir, $new->getWorkingDir());
@@ -90,7 +90,7 @@ class AdminTest extends AbstractTest
         self::registerDeletion($new);
 
         $head = $new->getHead();
-        $this->assertTrue($head instanceof Branch, 'HEAD is a branch');
+        $this->assertInstanceOf(Branch::class, $head, 'HEAD is a branch');
         $this->assertEquals('new-feature', $head->getName(), 'HEAD is branch new-feature');
     }
 
@@ -105,7 +105,7 @@ class AdminTest extends AbstractTest
         self::registerDeletion($new);
 
         $head = $new->getHead();
-        $this->assertTrue($head instanceof Branch, 'HEAD is a branch');
+        $this->assertInstanceOf(Branch::class, $head, 'HEAD is a branch');
         $this->assertEquals('new-feature', $head->getName(), 'HEAD is branch new-feature');
     }
 
@@ -120,14 +120,14 @@ class AdminTest extends AbstractTest
 
         $newRefs = array_keys($new->getReferences()->getAll());
 
-        $this->assertTrue(in_array('refs/heads/master', $newRefs));
-        $this->assertTrue(in_array('refs/tags/0.1', $newRefs));
+        $this->assertContains('refs/heads/master', $newRefs);
+        $this->assertContains('refs/tags/0.1', $newRefs);
         $this->assertEquals($newDir, $new->getGitDir());
 
         if ($repository->isBare()) {
-            $this->assertTrue(in_array('refs/heads/new-feature', $newRefs));
+            $this->assertContains('refs/heads/new-feature', $newRefs);
         } else {
-            $this->assertTrue(in_array('refs/remotes/origin/new-feature', $newRefs));
+            $this->assertContains('refs/remotes/origin/new-feature', $newRefs);
         }
     }
 
@@ -169,8 +169,8 @@ class AdminTest extends AbstractTest
 
         $newRefs = array_keys($new->getReferences()->getAll());
 
-        $this->assertTrue(in_array('refs/heads/master', $newRefs));
-        $this->assertTrue(in_array('refs/tags/0.1', $newRefs));
+        $this->assertContains('refs/heads/master', $newRefs);
+        $this->assertContains('refs/tags/0.1', $newRefs);
 
         $this->assertEquals($newDir.'/.git', $new->getGitDir());
         $this->assertEquals($newDir, $new->getWorkingDir());

--- a/tests/Gitonomy/Git/Tests/CommitTest.php
+++ b/tests/Gitonomy/Git/Tests/CommitTest.php
@@ -13,6 +13,7 @@
 namespace Gitonomy\Git\Tests;
 
 use Gitonomy\Git\Commit;
+use Gitonomy\Git\Tree;
 use Gitonomy\Git\Diff\Diff;
 
 class CommitTest extends AbstractTest
@@ -26,7 +27,7 @@ class CommitTest extends AbstractTest
 
         $diff = $commit->getDiff();
 
-        $this->assertTrue($diff instanceof Diff, 'getDiff() returns a Diff object');
+        $this->assertInstanceOf(Diff::class, $diff, 'getDiff() returns a Diff object');
     }
 
     /**
@@ -47,7 +48,7 @@ class CommitTest extends AbstractTest
      */
     public function testInvalideHashThrowException($repository)
     {
-        $commit = new Commit($repository, 'that-hash-doest-not-exists');
+        new Commit($repository, 'that-hash-doest-not-exists');
     }
 
     /**
@@ -67,7 +68,7 @@ class CommitTest extends AbstractTest
     {
         $commit = $repository->getCommit(self::INITIAL_COMMIT);
 
-        $this->assertEquals(0, count($commit->getParentHashes()), 'No parent on initial commit');
+        $this->assertCount(0, $commit->getParentHashes(), 'No parent on initial commit');
     }
 
     /**
@@ -78,7 +79,7 @@ class CommitTest extends AbstractTest
         $commit = $repository->getCommit(self::LONGFILE_COMMIT);
         $parents = $commit->getParentHashes();
 
-        $this->assertEquals(1, count($parents), 'One parent found');
+        $this->assertCount(1, $parents, 'One parent found');
         $this->assertEquals(self::BEFORE_LONGFILE_COMMIT, $parents[0], 'Parent hash is correct');
     }
 
@@ -90,8 +91,8 @@ class CommitTest extends AbstractTest
         $commit = $repository->getCommit(self::LONGFILE_COMMIT);
         $parents = $commit->getParents();
 
-        $this->assertEquals(1, count($parents), 'One parent found');
-        $this->assertTrue($parents[0] instanceof Commit, 'First parent is a Commit object');
+        $this->assertCount(1, $parents, 'One parent found');
+        $this->assertInstanceOf(Commit::class, $parents[0], 'First parent is a Commit object');
         $this->assertEquals(self::BEFORE_LONGFILE_COMMIT, $parents[0]->getHash(), "First parents's hash is correct");
     }
 
@@ -112,7 +113,7 @@ class CommitTest extends AbstractTest
     {
         $commit = $repository->getCommit(self::LONGFILE_COMMIT);
 
-        $this->assertInstanceOf('Gitonomy\Git\Tree', $commit->getTree(), 'Tree is a tree');
+        $this->assertInstanceOf(Tree::class, $commit->getTree(), 'Tree is a tree');
         $this->assertEquals('b06890c7b10904979d2f69613c2ccda30aafe262', $commit->getTree()->getHash(), 'Tree hash is correct');
     }
 

--- a/tests/Gitonomy/Git/Tests/DiffTest.php
+++ b/tests/Gitonomy/Git/Tests/DiffTest.php
@@ -45,7 +45,7 @@ class DiffTest extends AbstractTest
     {
         $files = $diff->getFiles();
 
-        $this->assertEquals(2, count($files), '1 file in diff');
+        $this->assertCount(2, $files, '1 file in diff');
 
         $this->assertTrue($files[0]->isCreation(), 'script_A.php created');
 
@@ -65,7 +65,7 @@ class DiffTest extends AbstractTest
     {
         $files = $repository->getCommit(self::BEFORE_LONGFILE_COMMIT)->getDiff()->getFiles();
 
-        $this->assertEquals(1, count($files), '1 files in diff');
+        $this->assertCount(1, $files, '1 files in diff');
 
         $this->assertTrue($files[0]->isModification(), 'image.jpg modified');
 
@@ -86,7 +86,7 @@ class DiffTest extends AbstractTest
     {
         $files = $repository->getCommit(self::DELETE_COMMIT)->getDiff()->getFiles();
 
-        $this->assertEquals(1, count($files), '1 files modified');
+        $this->assertCount(1, $files, '1 files modified');
 
         $this->assertTrue($files[0]->isDeletion(), 'File deletion');
         $this->assertEquals('script_B.php', $files[0]->getOldName(), 'verify old filename');
@@ -100,7 +100,7 @@ class DiffTest extends AbstractTest
     {
         $files = $repository->getCommit(self::RENAME_COMMIT)->getDiff()->getFiles();
 
-        $this->assertEquals(1, count($files), '1 files modified');
+        $this->assertCount(1, $files, '1 files modified');
 
         $this->assertTrue($files[0]->isModification());
         $this->assertTrue($files[0]->isRename());
@@ -116,7 +116,7 @@ class DiffTest extends AbstractTest
     {
         $files = $repository->getCommit(self::CHANGEMODE_COMMIT)->getDiff()->getFiles();
 
-        $this->assertEquals(1, count($files), '1 files modified');
+        $this->assertCount(1, $files, '1 files modified');
 
         $this->assertTrue($files[0]->isModification());
         $this->assertTrue($files[0]->isChangeMode());

--- a/tests/Gitonomy/Git/Tests/HooksTest.php
+++ b/tests/Gitonomy/Git/Tests/HooksTest.php
@@ -49,7 +49,7 @@ class HooksTest extends AbstractTest
         $file = $this->hookPath($repository, $hook);
 
         $this->assertTrue($repository->getHooks()->has($hook), "hook $hook in repository");
-        $this->assertTrue(file_exists($file), "Hook $hook is present");
+        $this->assertFileExists($file, "Hook $hook is present");
     }
 
     public function assertNoHook($repository, $hook)
@@ -57,7 +57,7 @@ class HooksTest extends AbstractTest
         $file = $this->hookPath($repository, $hook);
 
         $this->assertFalse($repository->getHooks()->has($hook), "No hook $hook in repository");
-        $this->assertFalse(file_exists($file), "Hook $hook is not present");
+        $this->assertFileNotExists($file, "Hook $hook is not present");
     }
 
     /**
@@ -154,7 +154,7 @@ class HooksTest extends AbstractTest
         touch($file);
 
         $repository->getHooks()->remove('foo');
-        $this->assertFalse(file_exists($file));
+        $this->assertFileNotExists($file);
     }
 
     /**

--- a/tests/Gitonomy/Git/Tests/LogTest.php
+++ b/tests/Gitonomy/Git/Tests/LogTest.php
@@ -22,8 +22,8 @@ class LogTest extends AbstractTest
         $logReadme = $repository->getLog(self::LONGFILE_COMMIT, 'README');
         $logImage = $repository->getLog(self::LONGFILE_COMMIT, 'image.jpg');
 
-        $this->assertEquals(3, count($logReadme));
-        $this->assertEquals(2, count($logImage));
+        $this->assertCount(3, $logReadme);
+        $this->assertCount(2, $logImage);
     }
 
     /**
@@ -35,7 +35,7 @@ class LogTest extends AbstractTest
 
         $commits = $log->getCommits();
 
-        $this->assertEquals(3, count($commits), '3 commits in log');
+        $this->assertCount(3, $commits, '3 commits in log');
         $this->assertEquals(self::LONGFILE_COMMIT, $commits[0]->getHash(), 'First is requested one');
         $this->assertEquals(self::BEFORE_LONGFILE_COMMIT, $commits[1]->getHash(), "Second is longfile parent\'s");
     }

--- a/tests/Gitonomy/Git/Tests/PushReferenceTest.php
+++ b/tests/Gitonomy/Git/Tests/PushReferenceTest.php
@@ -52,7 +52,7 @@ class PushReferenceTest extends AbstractTest
         $ref = new PushReference($repository, 'foo', self::INITIAL_COMMIT, self::LONGFILE_COMMIT);
 
         $log = $ref->getLog()->getCommits();
-        $this->assertEquals(7, count($log), '7 commits in log');
+        $this->assertCount(7, $log, '7 commits in log');
         $this->assertEquals('add a long file', $log[0]->getShortMessage(), 'First commit is correct');
     }
 
@@ -65,7 +65,7 @@ class PushReferenceTest extends AbstractTest
     {
         $ref = new PushReference($repository, 'foo', self::INITIAL_COMMIT, self::SIGNED_COMMIT);
         $log = $ref->getLog()->getCommits();
-        $this->assertEquals(16, count($log), '16 commits in log');
+        $this->assertCount(16, $log, '16 commits in log');
         $this->assertEquals('signed commit', $log[0]->getShortMessage(), 'Last commit is correct');
     }
 
@@ -77,7 +77,7 @@ class PushReferenceTest extends AbstractTest
         $ref = new PushReference($repository, 'foo', PushReference::ZERO, self::LONGFILE_COMMIT);
 
         $log = $ref->getLog([self::INITIAL_COMMIT])->getCommits();
-        $this->assertEquals(7, count($log), '7 commits in log');
+        $this->assertCount(7, $log, '7 commits in log');
         $this->assertEquals('add a long file', $log[0]->getShortMessage(), 'First commit is correct');
     }
 }

--- a/tests/Gitonomy/Git/Tests/ReferenceTest.php
+++ b/tests/Gitonomy/Git/Tests/ReferenceTest.php
@@ -35,7 +35,7 @@ class ReferenceTest extends AbstractTest
     {
         $branch = $repository->getReferences()->getBranch('master');
 
-        $this->assertTrue($branch instanceof Branch, 'Branch object is correct type');
+        $this->assertInstanceOf(Branch::class, $branch, 'Branch object is correct type');
         $this->assertEquals($branch->getCommitHash(), $branch->getCommit()->getHash(), 'Hash is correctly resolved');
     }
 
@@ -63,7 +63,7 @@ class ReferenceTest extends AbstractTest
      */
     public function testGetBranch_NotExisting_Error($repository)
     {
-        $branch = $repository->getReferences()->getBranch('notexisting');
+        $repository->getReferences()->getBranch('notexisting');
     }
 
     /**
@@ -73,7 +73,7 @@ class ReferenceTest extends AbstractTest
     {
         $tag = $repository->getReferences()->getTag('0.1');
 
-        $this->assertTrue($tag instanceof Tag, 'Tag object is correct type');
+        $this->assertInstanceOf(Tag::class, $tag, 'Tag object is correct type');
         $this->assertFalse($tag->isAnnotated(), 'Tag is not annotated');
 
         $this->assertEquals(self::LONGFILE_COMMIT, $tag->getCommitHash(), 'Commit hash is correct');
@@ -87,7 +87,7 @@ class ReferenceTest extends AbstractTest
     {
         $tag = $repository->getReferences()->getTag('annotated');
 
-        $this->assertTrue($tag instanceof Tag, 'Tag object is correct type');
+        $this->assertInstanceOf(Tag::class, $tag, 'Tag object is correct type');
         $this->assertTrue($tag->isAnnotated(), 'Tag is annotated');
         $this->assertFalse($tag->isSigned(), 'Tag is not signed');
 
@@ -105,7 +105,7 @@ class ReferenceTest extends AbstractTest
      */
     public function testGetTag_NotExisting_Error($repository)
     {
-        $branch = $repository->getReferences()->getTag('notexisting');
+        $repository->getReferences()->getTag('notexisting');
     }
 
     /**
@@ -116,8 +116,8 @@ class ReferenceTest extends AbstractTest
         $commit = $repository->getReferences()->getTag('0.1')->getCommit();
         $resolved = $repository->getReferences()->resolve($commit->getHash());
 
-        $this->assertEquals(1, count($resolved), '1 revision resolved');
-        $this->assertTrue(reset($resolved) instanceof Tag, 'Resolved object is a tag');
+        $this->assertCount(1, $resolved, '1 revision resolved');
+        $this->assertInstanceOf(Tag::class, reset($resolved), 'Resolved object is a tag');
     }
 
     /**
@@ -128,8 +128,8 @@ class ReferenceTest extends AbstractTest
         $commit = $repository->getReferences()->getTag('0.1')->getCommit();
         $resolved = $repository->getReferences()->resolveTags($commit->getHash());
 
-        $this->assertEquals(1, count($resolved), '1 revision resolved');
-        $this->assertTrue(reset($resolved) instanceof Tag, 'Resolved object is a tag');
+        $this->assertCount(1, $resolved, '1 revision resolved');
+        $this->assertInstanceOf(Tag::class, reset($resolved), 'Resolved object is a tag');
     }
 
     /**
@@ -142,12 +142,12 @@ class ReferenceTest extends AbstractTest
         $resolved = $repository->getReferences()->resolveBranches($master->getCommitHash());
 
         if ($repository->isBare()) {
-            $this->assertEquals(1, count($resolved), '1 revision resolved');
+            $this->assertCount(1, $resolved, '1 revision resolved');
         } else {
-            $this->assertEquals(2, count($resolved), '2 revision resolved');
+            $this->assertCount(2, $resolved, '2 revision resolved');
         }
 
-        $this->assertTrue(reset($resolved) instanceof Branch, 'Resolved object is a branch');
+        $this->assertInstanceOf(Branch::class, reset($resolved), 'Resolved object is a branch');
     }
 
     /**

--- a/tests/Gitonomy/Git/Tests/RepositoryTest.php
+++ b/tests/Gitonomy/Git/Tests/RepositoryTest.php
@@ -24,7 +24,7 @@ class RepositoryTest extends AbstractTest
     {
         $blob = $repository->getCommit(self::LONGFILE_COMMIT)->getTree()->resolvePath('README.md');
 
-        $this->assertTrue($blob instanceof Blob, 'getBlob() returns a Blob object');
+        $this->assertInstanceOf(Blob::class, $blob, 'getBlob() returns a Blob object');
         $this->assertContains('Foo Bar project', $blob->getContent(), 'file is correct');
     }
 

--- a/tests/Gitonomy/Git/Tests/RevisionTest.php
+++ b/tests/Gitonomy/Git/Tests/RevisionTest.php
@@ -25,11 +25,11 @@ class RevisionTest extends AbstractTest
     {
         $revision = $repository->getRevision(self::LONGFILE_COMMIT.'^');
 
-        $this->assertTrue($revision instanceof Revision, 'Revision object type');
+        $this->assertInstanceOf(Revision::class, $revision, 'Revision object type');
 
         $commit = $revision->getCommit();
 
-        $this->assertTrue($commit instanceof Commit, 'getCommit returns a Commit');
+        $this->assertInstanceOf(Commit::class, $commit, 'getCommit returns a Commit');
 
         $this->assertEquals(self::BEFORE_LONGFILE_COMMIT, $commit->getHash(), 'Resolution is correct');
     }
@@ -53,7 +53,7 @@ class RevisionTest extends AbstractTest
 
         $log = $revision->getLog(null, 2, 3);
 
-        $this->assertTrue($log instanceof Log, 'Log type object');
+        $this->assertInstanceOf(Log::class, $log, 'Log type object');
         $this->assertEquals(2, $log->getOffset(), 'Log offset is passed');
         $this->assertEquals(3, $log->getLimit(), 'Log limit is passed');
         $this->assertEquals([$revision], $log->getRevisions()->getAll(), 'Revision is passed');

--- a/tests/Gitonomy/Git/Tests/TreeTest.php
+++ b/tests/Gitonomy/Git/Tests/TreeTest.php
@@ -27,10 +27,10 @@ class TreeTest extends AbstractTest
 
         $entries = $tree->getEntries();
 
-        $this->assertTrue(isset($entries['long.php']), 'long.php is present');
+        $this->assertNotEmpty($entries['long.php'], 'long.php is present');
         $this->assertTrue($entries['long.php'][1] instanceof Blob, 'long.php is a Blob');
 
-        $this->assertTrue(isset($entries['README.md']), 'README.md is present');
+        $this->assertNotEmpty($entries['README.md'], 'README.md is present');
         $this->assertTrue($entries['README.md'][1] instanceof Blob, 'README.md is a Blob');
     }
 
@@ -45,6 +45,6 @@ class TreeTest extends AbstractTest
         $resolved = $tree->resolvePath($path);
         $entries = $resolved->getEntries();
 
-        $this->assertTrue(isset($entries['d']), 'Successfully resolved source folder');
+        $this->assertNotEmpty($entries['d'], 'Successfully resolved source folder');
     }
 }

--- a/tests/Gitonomy/Git/Tests/WorkingCopyTest.php
+++ b/tests/Gitonomy/Git/Tests/WorkingCopyTest.php
@@ -35,7 +35,7 @@ class WorkingCopyTest extends AbstractTest
         $wc->checkout('origin/new-feature', 'new-feature');
 
         $head = $repository->getHead();
-        $this->assertTrue($head instanceof Branch, 'HEAD is a branch');
+        $this->assertInstanceOf(Branch::class, $head, 'HEAD is a branch');
         $this->assertEquals('new-feature', $head->getName(), 'HEAD is branch new-feature');
     }
 


### PR DESCRIPTION
# Changed log
- Using the `suffix` attribute defined on `phpunit.xml.dist` to mark test classes.
- According to the [PHPUnit fixtures reference](https://phpunit.de/manual/6.5/en/fixtures.html), the `setUp` method and `tearDown` method are `protected`, not `public`.
- Using the `assertInstanceOf` to assert expected class instance is same as `$actual`.
- Using the `assertCount` to assert the expected count value is same as `$actual` count value.
- Using the `assertDirectoryExists` to assert the specific directory is existed.
- Using the `assertContains` to assert the expected value contains on specific array.
- Using the `assertNotEmpty` to assert the specific value is set.