### PR TITLE
Enhance exception tests

### DIFF
--- a/tests/Gitonomy/Git/Tests/AdminTest.php
+++ b/tests/Gitonomy/Git/Tests/AdminTest.php
@@ -13,6 +13,7 @@
 namespace Gitonomy\Git\Tests;
 
 use Gitonomy\Git\Admin;
+use Gitonomy\Git\Exception\RuntimeException;
 use Gitonomy\Git\Reference\Branch;
 use Gitonomy\Git\Repository;
 
@@ -148,11 +149,10 @@ class AdminTest extends AbstractTest
         $this->assertFalse(Admin::isValidRepository($url));
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testExistingFile()
     {
+        $this->expectException(RuntimeException::class);
+
         $file = $this->tmpDir.'/test';
         touch($file);
 

--- a/tests/Gitonomy/Git/Tests/BlobTest.php
+++ b/tests/Gitonomy/Git/Tests/BlobTest.php
@@ -12,6 +12,8 @@
 
 namespace Gitonomy\Git\Tests;
 
+use Gitonomy\Git\Exception\RuntimeException;
+
 class BlobTest extends AbstractTest
 {
     const README_FRAGMENT = 'Foo Bar project';
@@ -33,10 +35,11 @@ class BlobTest extends AbstractTest
 
     /**
      * @dataProvider provideFoobar
-     * @expectedException RuntimeException
      */
     public function testNotExisting($repository)
     {
+        $this->expectException(RuntimeException::class);
+
         $blob = $repository->getBlob('foobar');
         $blob->getContent();
     }

--- a/tests/Gitonomy/Git/Tests/CommitTest.php
+++ b/tests/Gitonomy/Git/Tests/CommitTest.php
@@ -14,6 +14,8 @@ namespace Gitonomy\Git\Tests;
 
 use Gitonomy\Git\Commit;
 use Gitonomy\Git\Diff\Diff;
+use Gitonomy\Git\Exception\InvalidArgumentException;
+use Gitonomy\Git\Exception\ReferenceNotFoundException;
 use Gitonomy\Git\Tree;
 
 class CommitTest extends AbstractTest
@@ -42,12 +44,12 @@ class CommitTest extends AbstractTest
 
     /**
      * @dataProvider provideFoobar
-     *
-     * @expectedException Gitonomy\Git\Exception\ReferenceNotFoundException
-     * @expectedExceptionMessage Reference not found: "that-hash-doest-not-exists"
      */
     public function testInvalideHashThrowException($repository)
     {
+        $this->expectException(ReferenceNotFoundException::class);
+        $this->expectExceptionMessage('Reference not found: "that-hash-doest-not-exists"');
+
         new Commit($repository, 'that-hash-doest-not-exists');
     }
 
@@ -241,11 +243,12 @@ EOL;
     }
 
     /**
-     * @expectedException InvalidArgumentException
      * @dataProvider provideFoobar
      */
     public function testGetIncludingBranchesException($repository)
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $commit = $repository->getCommit(self::INITIAL_COMMIT);
 
         $commit->getIncludingBranches(false, false);

--- a/tests/Gitonomy/Git/Tests/HooksTest.php
+++ b/tests/Gitonomy/Git/Tests/HooksTest.php
@@ -12,6 +12,9 @@
 
 namespace Gitonomy\Git\Tests;
 
+use Gitonomy\Git\Exception\InvalidArgumentException;
+use Gitonomy\Git\Exception\LogicException;
+
 class HooksTest extends AbstractTest
 {
     private static $symlinkOnWindows = null;
@@ -72,10 +75,11 @@ class HooksTest extends AbstractTest
 
     /**
      * @dataProvider provideFoobar
-     * @expectedException InvalidArgumentException
      */
     public function testGet_InvalidName_ThrowsException($repository)
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $repository->getHooks()->get('foo');
     }
 
@@ -105,10 +109,11 @@ class HooksTest extends AbstractTest
 
     /**
      * @dataProvider provideFoobar
-     * @expectedException LogicException
      */
     public function testSymlink_WithExisting_ThrowsLogicException($repository)
     {
+        $this->expectException(LogicException::class);
+
         $this->markAsSkippedIfSymlinkIsMissing();
 
         $file = $this->hookPath($repository, 'target-symlink');
@@ -141,7 +146,7 @@ class HooksTest extends AbstractTest
     {
         $repository->getHooks()->set('foo', 'bar');
 
-        $this->expectException('LogicException');
+        $this->expectException(LogicException::class);
         $repository->getHooks()->set('foo', 'bar');
     }
 
@@ -159,10 +164,11 @@ class HooksTest extends AbstractTest
 
     /**
      * @dataProvider provideFoobar
-     * @expectedException LogicException
      */
     public function testRemove_NotExisting_ThrowsLogicException($repository)
     {
+        $this->expectException(LogicException::class);
+
         $repository->getHooks()->remove('foo');
     }
 

--- a/tests/Gitonomy/Git/Tests/ReferenceTest.php
+++ b/tests/Gitonomy/Git/Tests/ReferenceTest.php
@@ -12,13 +12,12 @@
 
 namespace Gitonomy\Git\Tests;
 
+use Gitonomy\Git\Exception\ReferenceNotFoundException;
 use Gitonomy\Git\Reference\Branch;
 use Gitonomy\Git\Reference\Tag;
 
 class ReferenceTest extends AbstractTest
 {
-    private $references;
-
     /**
      * @dataProvider provideEmpty
      */
@@ -59,10 +58,11 @@ class ReferenceTest extends AbstractTest
 
     /**
      * @dataProvider provideFoobar
-     * @expectedException Gitonomy\Git\Exception\ReferenceNotFoundException
      */
     public function testGetBranch_NotExisting_Error($repository)
     {
+        $this->expectException(ReferenceNotFoundException::class);
+
         $repository->getReferences()->getBranch('notexisting');
     }
 
@@ -101,10 +101,11 @@ class ReferenceTest extends AbstractTest
 
     /**
      * @dataProvider provideFoobar
-     * @expectedException Gitonomy\Git\Exception\ReferenceNotFoundException
      */
     public function testGetTag_NotExisting_Error($repository)
     {
+        $this->expectException(ReferenceNotFoundException::class);
+
         $repository->getReferences()->getTag('notexisting');
     }
 

--- a/tests/Gitonomy/Git/Tests/RepositoryTest.php
+++ b/tests/Gitonomy/Git/Tests/RepositoryTest.php
@@ -13,6 +13,7 @@
 namespace Gitonomy\Git\Tests;
 
 use Gitonomy\Git\Blob;
+use Gitonomy\Git\Exception\RuntimeException;
 use Prophecy\Argument;
 
 class RepositoryTest extends AbstractTest
@@ -78,13 +79,14 @@ class RepositoryTest extends AbstractTest
 
     /**
      * @dataProvider provideFoobar
-     * @expectedException RuntimeException
      */
     public function testLoggerNOk($repository)
     {
         if (!interface_exists('Psr\Log\LoggerInterface')) {
             $this->markTestSkipped();
         }
+
+        $this->expectException(RuntimeException::class);
 
         $loggerProphecy = $this->prophesize('Psr\Log\LoggerInterface');
         $loggerProphecy

--- a/tests/Gitonomy/Git/Tests/RevisionTest.php
+++ b/tests/Gitonomy/Git/Tests/RevisionTest.php
@@ -13,6 +13,7 @@
 namespace Gitonomy\Git\Tests;
 
 use Gitonomy\Git\Commit;
+use Gitonomy\Git\Exception\ReferenceNotFoundException;
 use Gitonomy\Git\Log;
 use Gitonomy\Git\Revision;
 
@@ -36,12 +37,13 @@ class RevisionTest extends AbstractTest
 
     /**
      * @dataProvider provideFoobar
-     * @expectedException Gitonomy\Git\Exception\ReferenceNotFoundException
-     * @expectedExceptionMessage Can not find revision "non-existent-commit"
      */
     public function testGetFailingReference($repository)
     {
-        $revision = $repository->getRevision('non-existent-commit')->getCommit();
+        $this->expectException(ReferenceNotFoundException::class);
+        $this->expectExceptionMessage('Can not find revision "non-existent-commit"');
+
+        $repository->getRevision('non-existent-commit')->getCommit();
     }
 
     /**

--- a/tests/Gitonomy/Git/Tests/WorkingCopyTest.php
+++ b/tests/Gitonomy/Git/Tests/WorkingCopyTest.php
@@ -13,15 +13,16 @@
 namespace Gitonomy\Git\Tests;
 
 use Gitonomy\Git\Admin;
+use Gitonomy\Git\Exception\LogicException;
+use Gitonomy\Git\Exception\RuntimeException;
 use Gitonomy\Git\Reference\Branch;
 
 class WorkingCopyTest extends AbstractTest
 {
-    /**
-     * @expectedException LogicException
-     */
     public function testNoWorkingCopyInBare()
     {
+        $this->expectException(LogicException::class);
+
         $path = self::createTempDir();
         $repo = Admin::init($path, true, self::getOptions());
 
@@ -70,11 +71,10 @@ class WorkingCopyTest extends AbstractTest
         $this->assertCount(1, $diffPending->getFiles());
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testCheckoutUnexisting()
     {
+        $this->expectException(RuntimeException::class);
+
         self::createFoobarRepository(false)->getWorkingCopy()->checkout('foobar');
     }
 


### PR DESCRIPTION
# Changed log
- To support future `PHPUnit 8.x` versions about deprecated `@expectedException` warning message, using the `expectException` and `expectExceptionMessage` instead.
- Removing unused variables.

The deprecated warning message is as follows:

```
 with data set "empty string" ('')
The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageRegExp() instead.
```

The related issue is available [here](https://github.com/sebastianbergmann/phpunit/issues/3332).