### PR TITLE
Php only Repository::getsize

### DIFF
--- a/src/Gitonomy/Git/Repository.php
+++ b/src/Gitonomy/Git/Repository.php
@@ -415,15 +415,15 @@ class Repository
      */
     public function getSize()
     {
-        $totalKilobytes = 0;
+        $totalBytes = 0;
         $path = realpath($this->gitDir);
         if ($path && file_exists($path)) {
             foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS)) as $object) {
-                $totalKilobytes += $object->getSize();
+                $totalBytes += $object->getSize();
             }
         }
 
-        return (int) ($totalKilobytes / 1000 + 0.5);
+        return (int) ($totalBytes / 1000 + 0.5);
     }
 
     /**

--- a/src/Gitonomy/Git/Repository.php
+++ b/src/Gitonomy/Git/Repository.php
@@ -411,30 +411,19 @@ class Repository
     /**
      * Returns the size of repository, in kilobytes.
      *
-     * @throws RuntimeException An error occurred while computing size
-     *
      * @return int A sum, in kilobytes
      */
     public function getSize()
     {
-        $process = new Process(['du', '-skc', $this->gitDir]);
-        $process->run();
-
-        if (!preg_match('/(\d+)\s+total$/', trim($process->getOutput()), $vars)) {
-            $message = sprintf("Unable to parse process output\ncommand: %s\noutput: %s", $process->getCommandLine(), $process->getOutput());
-
-            if (null !== $this->logger) {
-                $this->logger->error($message);
+        $totalKilobytes = 0;
+        $path = realpath($this->gitDir);
+        if ($path && file_exists($path)) {
+            foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS)) as $object) {
+                $totalKilobytes += $object->getSize();
             }
-
-            if (true === $this->debug) {
-                throw new RuntimeException('unable to parse repository size output');
-            }
-
-            return;
         }
 
-        return $vars[1];
+        return (int) ($totalKilobytes / 1000 + 0.5);
     }
 
     /**

--- a/tests/Gitonomy/Git/Tests/RepositoryTest.php
+++ b/tests/Gitonomy/Git/Tests/RepositoryTest.php
@@ -35,7 +35,10 @@ class RepositoryTest extends AbstractTest
     public function testGetSize($repository)
     {
         $size = $repository->getSize();
-        $this->assertGreaterThan(70, $size, 'Repository is greater than 70KB');
+        $this->assertGreaterThanOrEqual(69, $size, 'Repository is >= 69KB');
+
+        // This should be true for a while, but may need to be changed in the future
+        $this->assertLessThan(80, $size, 'Repository is less than 80KB');
     }
 
     public function testIsBare()

--- a/tests/Gitonomy/Git/Tests/RepositoryTest.php
+++ b/tests/Gitonomy/Git/Tests/RepositoryTest.php
@@ -35,9 +35,7 @@ class RepositoryTest extends AbstractTest
     public function testGetSize($repository)
     {
         $size = $repository->getSize();
-        $this->assertGreaterThanOrEqual(69, $size, 'Repository is >= 69KB');
-
-        // This should be true for a while, but may need to be changed in the future
+        $this->assertGreaterThanOrEqual(69, $size, 'Repository is at least 69KB');
         $this->assertLessThan(80, $size, 'Repository is less than 80KB');
     }
 


### PR DESCRIPTION
This is the PHP implementation only version of Repository::getSize.

There are a couple of interesting things I discovered while doing this PR.

- Apparently the tests run twice, The second time the repository is bigger.
- The DU command measures in increments of 1000, not 1024, which is also a valid measurement for K in computers.  You say tomato, I say ...

So in the first run of the test, the size of the repo comes in just over 69,000 bytes, as measured by PHP and filesize.  On the second run of the test, it comes in at over 70,000 bytes.  So I changed the test to >= 69.

The second thing I did was put in a max size test, since that may detect a bug where you don't correctly divide by 1000. Don't ask how I know this.

So there is now an upper limit test of 80K, which should be OK for a while.

But in the end, I think the unit tests numbers are the correct numbers for the tests run.