### PR TITLE
Allow reload references from filesystem

### DIFF
--- a/src/Gitonomy/Git/Repository.php
+++ b/src/Gitonomy/Git/Repository.php
@@ -315,11 +315,13 @@ class Repository
     /**
      * Returns the reference list associated to the repository.
      *
+     * @param bool $reload Reload references from the filesystem
+     *
      * @return ReferenceBag
      */
-    public function getReferences()
+    public function getReferences($reload = false)
     {
-        if (null === $this->referenceBag) {
+        if (null === $this->referenceBag || $reload) {
             $this->referenceBag = new ReferenceBag($this);
         }
 


### PR DESCRIPTION
This is useful to refresh branch information like commit hash, after running git pull with `$repository->run('pull');` (like suggested in https://github.com/gitonomy/gitlib/issues/163)