### PR TITLE
{@inheritdoc} to @inheritDoc Hacktoberfest

### DIFF
--- a/src/Gitonomy/Git/Commit.php
+++ b/src/Gitonomy/Git/Commit.php
@@ -334,7 +334,7 @@ class Commit extends Revision
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getCommit()
     {


### PR DESCRIPTION
Minor issue, but for Hacktoberfest, I thought I would correct it.

{@inheritdoc} should be @inheritDoc

See [Inheritance](https://docs.phpdoc.org/latest/guides/inheritance.html)