### PR TITLE
Don't pass null as second parameter to preg_match

### DIFF
--- a/src/Gitonomy/Git/Parser/DiffParser.php
+++ b/src/Gitonomy/Git/Parser/DiffParser.php
@@ -90,8 +90,8 @@ class DiffParser extends ParserBase
 
             $oldName = $oldName === '/dev/null' ? null : substr($oldName, 2);
             $newName = $newName === '/dev/null' ? null : substr($newName, 2);
-            $oldIndex !== null ? : '';
-            $newIndex !== null ? : '';
+            $oldIndex !== null ?: '';
+            $newIndex !== null ?: '';
             $oldIndex = preg_match('/^0+$/', $oldIndex) ? null : $oldIndex;
             $newIndex = preg_match('/^0+$/', $newIndex) ? null : $newIndex;
             $file = new File($oldName, $newName, $oldMode, $newMode, $oldIndex, $newIndex, $isBinary);

--- a/src/Gitonomy/Git/Parser/DiffParser.php
+++ b/src/Gitonomy/Git/Parser/DiffParser.php
@@ -90,8 +90,8 @@ class DiffParser extends ParserBase
 
             $oldName = $oldName === '/dev/null' ? null : substr($oldName, 2);
             $newName = $newName === '/dev/null' ? null : substr($newName, 2);
-            $oldIndex = preg_match('/^0+$/', $oldIndex) ? null : $oldIndex;
-            $newIndex = preg_match('/^0+$/', $newIndex) ? null : $newIndex;
+            $oldIndex = preg_match('/^0+$/', $oldIndex ?? '') ? null : $oldIndex;
+            $newIndex = preg_match('/^0+$/', $newIndex ?? '') ? null : $newIndex;
             $file = new File($oldName, $newName, $oldMode, $newMode, $oldIndex, $newIndex, $isBinary);
 
             // 5. Diff

--- a/src/Gitonomy/Git/Parser/DiffParser.php
+++ b/src/Gitonomy/Git/Parser/DiffParser.php
@@ -90,8 +90,10 @@ class DiffParser extends ParserBase
 
             $oldName = $oldName === '/dev/null' ? null : substr($oldName, 2);
             $newName = $newName === '/dev/null' ? null : substr($newName, 2);
-            $oldIndex = preg_match('/^0+$/', $oldIndex ?? '') ? null : $oldIndex;
-            $newIndex = preg_match('/^0+$/', $newIndex ?? '') ? null : $newIndex;
+            $oldIndex !== null ? : '';
+            $newIndex !== null ? : '';
+            $oldIndex = preg_match('/^0+$/', $oldIndex) ? null : $oldIndex;
+            $newIndex = preg_match('/^0+$/', $newIndex) ? null : $newIndex;
             $file = new File($oldName, $newName, $oldMode, $newMode, $oldIndex, $newIndex, $isBinary);
 
             // 5. Diff


### PR DESCRIPTION
Found this on my website where I access git commits as a diff. [PHPFUI/Instadoc](http://phpfui.com/?n=Gitonomy%5CGit%5CParser&c=DiffParser&p=g#) click on the top two commits to see the error in the wild. Will be fixed automatically when this PR is published. Site updates nightly.

This is just an 8.1 issue.

There may be other places this happens, but I have only run into this one.