### PR TITLE
Assign to variable to prevent null value

### DIFF
--- a/src/Gitonomy/Git/Parser/DiffParser.php
+++ b/src/Gitonomy/Git/Parser/DiffParser.php
@@ -90,8 +90,8 @@ class DiffParser extends ParserBase
 
             $oldName = $oldName === '/dev/null' ? null : substr($oldName, 2);
             $newName = $newName === '/dev/null' ? null : substr($newName, 2);
-            $oldIndex !== null ?: '';
-            $newIndex !== null ?: '';
+            $oldIndex = $oldIndex !== null ?: '';
+            $newIndex = $newIndex !== null ?: '';
             $oldIndex = preg_match('/^0+$/', $oldIndex) ? null : $oldIndex;
             $newIndex = preg_match('/^0+$/', $newIndex) ? null : $newIndex;
             $file = new File($oldName, $newName, $oldMode, $newMode, $oldIndex, $newIndex, $isBinary);


### PR DESCRIPTION
Sorry about this guys. My PHP 8.1 fix for not passing null was derailed by PHP 5.6 backport. I forgot to assign the value! AARRG!! I could have just put the expression into the function call directly, but I tend to do it outside, as I think it makes the code a little less complex and easier to read.

Again, my apologies.
