### PR TITLE
Added tests for empty commit messages

### DIFF
--- a/tests/Gitonomy/Git/Tests/AbstractTest.php
+++ b/tests/Gitonomy/Git/Tests/AbstractTest.php
@@ -20,6 +20,7 @@ abstract class AbstractTest extends TestCase
 {
     const REPOSITORY_URL = 'https://github.com/gitonomy/foobar.git';
 
+    const NO_MESSAGE_COMMIT = '011cd0c1625190d2959ee9a8f9f822006d94b661';
     const LONGFILE_COMMIT = '4f17752acc9b7c54ba679291bf24cb7d354f0f4f';
     const BEFORE_LONGFILE_COMMIT = 'e0ec50e2af75fa35485513f60b2e658e245227e9';
     const LONGMESSAGE_COMMIT = '3febd664b6886344a9b32d70657687ea4b1b4fab';

--- a/tests/Gitonomy/Git/Tests/CommitTest.php
+++ b/tests/Gitonomy/Git/Tests/CommitTest.php
@@ -16,6 +16,7 @@ use Gitonomy\Git\Commit;
 use Gitonomy\Git\Diff\Diff;
 use Gitonomy\Git\Exception\InvalidArgumentException;
 use Gitonomy\Git\Exception\ReferenceNotFoundException;
+use Gitonomy\Git\Repository;
 use Gitonomy\Git\Tree;
 
 class CommitTest extends AbstractTest
@@ -187,6 +188,29 @@ class CommitTest extends AbstractTest
         $commit = $repository->getCommit(self::LONGFILE_COMMIT);
 
         $this->assertEquals('add a long file'."\n", $commit->getMessage());
+    }
+
+    /**
+     * @dataProvider provideFoobar
+     * @param $repository Repository
+     */
+    public function testGetEmptyMessage($repository)
+    {
+        $commit = $repository->getCommit(self::NO_MESSAGE_COMMIT);
+
+        $this->assertEquals('', $commit->getMessage());
+    }
+
+    /**
+     * @dataProvider provideFoobar
+     * @param $repository Repository
+     */
+    public function testGetEmptyMessageFromLog($repository)
+    {
+        $commit = $repository->getCommit(self::NO_MESSAGE_COMMIT);
+        $commitMessageFromLog = $commit->getLog()->getCommits()[0]->getMessage();
+
+        $this->assertEquals('', $commitMessageFromLog);
     }
 
     /**


### PR DESCRIPTION
Addressing the issue #61, I added tests to test the case for empty commit messages.
I used the [_LogPaser.php_ from 2014 ](https://github.com/gitonomy/gitlib/blob/cdee2fc1df500c8e7ab88fb405cfec34b4cd76f7/src/Gitonomy/Git/Parser/LogParser.php) to write the tests and was able to reproduce the same exception.

I figured out though that the newer version of gitlib already got the issue covered and that the issue is, in fact, was already fixed.
No new tag/version is needed, but it would be good to have these [regression tests](https://en.wikipedia.org/wiki/Regression_testing) to see that it was indeed fixed.

Pinging @lyrixx


