### PR TITLE
Check if a branch is merged (added code from PR #151)

### DIFF
--- a/src/Gitonomy/Git/Reference/Branch.php
+++ b/src/Gitonomy/Git/Reference/Branch.php
@@ -12,8 +12,10 @@
 
 namespace Gitonomy\Git\Reference;
 
+use Gitonomy\Git\Exception\ProcessException;
 use Gitonomy\Git\Exception\RuntimeException;
 use Gitonomy\Git\Reference;
+use Gitonomy\Git\Util\StringHelper;
 
 /**
  * Representation of a branch reference.
@@ -51,6 +53,50 @@ class Branch extends Reference
         $this->detectBranchType();
 
         return $this->local;
+    }
+
+    /**
+     *
+     * Check if this branch is merged to a destination branch
+     * Optionally, check only with remote branches
+     *
+     * @param string $destinationBranchName
+     * @param bool   $compareOnlyWithRemote
+     *
+     * @return null|bool
+     */
+    public function isMergedTo($destinationBranchName = 'master', $compareOnlyWithRemote = false)
+    {
+        $arguments = ['-a'];
+
+        if ($compareOnlyWithRemote) {
+            $arguments = ['-r'];
+        }
+
+        $arguments[] = '--merged';
+        $arguments[] = $destinationBranchName;
+
+        try {
+            $result = $this->repository->run('branch', $arguments);
+        } catch (ProcessException $e) {
+            throw new RuntimeException(
+                sprintf('Cannot determine if merged to the branch "%s"', $destinationBranchName),
+                $e->getCode(),
+                $e
+            );
+        }
+
+        if (!$result) {
+            return false;
+        }
+
+        $output = explode("\n", trim(str_replace(['*', 'remotes/'], '', $result)));
+        $filtered_output = array_filter($output, static function ($v) {
+            return false === StringHelper::strpos($v, '->');
+        });
+        $trimmed_output = array_map('trim', $filtered_output);
+
+        return (in_array($this->getName(), $trimmed_output, true));
     }
 
     private function detectBranchType()

--- a/tests/Gitonomy/Git/Tests/ReferenceTest.php
+++ b/tests/Gitonomy/Git/Tests/ReferenceTest.php
@@ -209,4 +209,28 @@ class ReferenceTest extends AbstractTest
         $branch->delete();
         $this->assertFalse($references->hasBranch('foobar'), 'Branch foobar removed');
     }
+
+    /**
+     * @dataProvider provideFoobar
+     */
+    public function testIsBranchMergedToMaster()
+    {
+        $repository = self::createFoobarRepository(false);
+
+        $master = $repository->getReferences()->getBranch('master');
+        $references = $repository->getReferences();
+        $branch = $references->createBranch('foobar-new', $master->getCommit()->getHash());
+
+        $this->assertTrue($branch->isMergedTo('master'));
+
+        $wc = $repository->getWorkingCopy();
+        $wc->checkout('foobar-new');
+
+        $file = $repository->getWorkingDir().'/foobar-test.txt';
+        file_put_contents($file, 'test');
+        $repository->run('add', [$file]);
+        $repository->run('commit', ['-m', 'foobar-test.txt updated']);
+
+        $this->assertFalse($branch->isMergedTo('master'));
+    }
 }


### PR DESCRIPTION
@shanecp added this pretty cool feature in the [PR#151](https://github.com/gitonomy/gitlib/pull/151) which got lost in time and fixes the [issue #111](https://github.com/gitonomy/gitlib/issues/111). 
The only reason why it wasn't accepted back then is because the symphony test failed - if it fails again this time, then I could take a look and fix it. @lyrixx 