### PR TITLE
Adds feature to check if a branch name exists in a repository without…

### DIFF
--- a/src/Gitonomy/Git/Admin.php
+++ b/src/Gitonomy/Git/Admin.php
@@ -68,6 +68,30 @@ class Admin
     }
 
     /**
+     * Checks the validity of a git repository url without cloning it and
+     * check if a certain branch exists in that repository.
+     *
+     * This will use the `ls-remote` command of git against the given url.
+     * Usually, this command returns 0 when successful, and 128 when the
+     * repository is not found.
+     *
+     * @param string $url        url of repository to check
+     * @param string $branchName name of branch to check
+     * @param array  $options    options for Repository creation
+     *
+     * @return bool true if url is valid and branch exists
+     */
+    public static function isValidRepositoryAndBranch($url, $branchName, array $options = [])
+    {
+        $process = static::getProcess('ls-remote', ['--heads', $url, $branchName], $options);
+
+        $process->run();
+        $processOutput = $process->getOutput();
+
+        return $process->isSuccessFul() && strpos($processOutput, $branchName) !== false;
+    }
+
+    /**
      * Clone a repository to a local path.
      *
      * @param string $path    indicates where to clone repository

--- a/tests/Gitonomy/Git/Tests/AdminTest.php
+++ b/tests/Gitonomy/Git/Tests/AdminTest.php
@@ -155,6 +155,24 @@ class AdminTest extends AbstractTest
         $this->assertFalse(Admin::isValidRepository($url));
     }
 
+    /**
+     * @dataProvider provideFoobar
+     */
+    public function testCheckValidRepositoryAndBranch($repository)
+    {
+        $url = $repository->getGitDir();
+        $this->assertTrue(Admin::isValidRepositoryAndBranch($url, 'master'));
+    }
+
+    /**
+     * @dataProvider provideFoobar
+     */
+    public function testCheckInvalidRepositoryAndBranch($repository)
+    {
+        $url = $repository->getGitDir();
+        $this->assertFalse(Admin::isValidRepositoryAndBranch($url, 'invalid-branch-name'));
+    }
+
     public function testExistingFile()
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
… cloning it.

----

I have a case where I want to verify before cloning a git repository that a branch name exists on the remote repo.
This adds such a feature.

It works with the command `git ls-remote --heads {repo-url} {branch-name}`
If the branch name is found in the output, we can assume the branch exists on the remote.

For example:
```bash
$ git ls-remote --heads https://github.com/gitonomy/foobar master
7e9ba14939b0ce67ab95d83e03bd64710db91ef4	refs/heads/master

$ git ls-remote --heads https://github.com/gitonomy/foobar invalid-branch-name

```
