### PR TITLE
[BUGFIX] Consider output of `stderr` in successful cases

### DIFF
--- a/src/Gitonomy/Git/Repository.php
+++ b/src/Gitonomy/Git/Repository.php
@@ -543,7 +543,7 @@ class Repository
 
         $process->run();
 
-        $output = $process->getOutput();
+        $output = $process->getOutput() ?: $process->getErrorOutput();
 
         if ($this->logger && $this->debug) {
             $duration = microtime(true) - $before;


### PR DESCRIPTION
Git writes the output of some commands into `stderr` instead of `stdout` (e.g. `push`). Using the option `--porcelain` doesn't always help in such cases as other information may be missing. To get the full output, `stderr` is now fetched in case `stdout` is empty.

Fixes: #205