### PR TITLE
Edge case: Empty message in the first commit

### DIFF
--- a/src/Gitonomy/Git/Parser/LogParser.php
+++ b/src/Gitonomy/Git/Parser/LogParser.php
@@ -49,7 +49,9 @@ class LogParser extends CommitParser
             $this->consumeGPGSignature();
 
             $this->consumeNewLine();
-            $this->consumeNewLine();
+            if ($this->cursor < strlen($this->content)) {
+                $this->consumeNewLine();
+            }
 
             $message = '';
             if ($this->expects('    ')) {

--- a/tests/Gitonomy/Git/Tests/LogTest.php
+++ b/tests/Gitonomy/Git/Tests/LogTest.php
@@ -76,4 +76,14 @@ class LogTest extends AbstractTest
             }
         }
     }
+
+    public function testFirstMessageEmpty()
+    {
+        $repository = $this->createEmptyRepository(false);
+        file_put_contents($repository->getWorkingDir().'/file', 'foo');
+        $repository->run('add', ['.']);
+        $repository->run('commit', ['--allow-empty-message', '--no-edit']);
+        $commits = $repository->getLog()->getCommits();
+        $this->assertCount(1, $commits);
+    }
 }

--- a/tests/Gitonomy/Git/Tests/LogTest.php
+++ b/tests/Gitonomy/Git/Tests/LogTest.php
@@ -80,9 +80,14 @@ class LogTest extends AbstractTest
     public function testFirstMessageEmpty()
     {
         $repository = $this->createEmptyRepository(false);
+        $repository->run('config', ['--local', 'user.name', '"Unit Test"']);
+        $repository->run('config', ['--local', 'user.email', '"unit_test@unit-test.com"']);
+
+        // Edge case: first commit lacks a message.
         file_put_contents($repository->getWorkingDir().'/file', 'foo');
         $repository->run('add', ['.']);
         $repository->run('commit', ['--allow-empty-message', '--no-edit']);
+
         $commits = $repository->getLog()->getCommits();
         $this->assertCount(1, $commits);
     }


### PR DESCRIPTION
Fixes #216 

Don't try to consume a 2nd new line when the first repository commit has an empty message.

