### PR TITLE
Detect binary file by NULL byte

### DIFF
--- a/src/Gitonomy/Git/Blob.php
+++ b/src/Gitonomy/Git/Blob.php
@@ -19,6 +19,8 @@ namespace Gitonomy\Git;
  */
 class Blob
 {
+    private const FIRST_FEW_BYTES = 8000;
+
     /**
      * @var Repository
      */
@@ -38,6 +40,11 @@ class Blob
      * @var string
      */
     protected $mimetype;
+
+    /**
+     * @var bool
+     */
+    protected $text;
 
     /**
      * @param Repository $repository Repository where the blob is located
@@ -103,6 +110,10 @@ class Blob
      */
     public function isText()
     {
-        return (bool) preg_match('#^text/|^application/xml#', $this->getMimetype());
+        if (null === $this->text) {
+            $this->text = !str_contains(substr($this->getContent(), 0, self::FIRST_FEW_BYTES), chr(0));
+        }
+
+        return $this->text;
     }
 }

--- a/src/Gitonomy/Git/Blob.php
+++ b/src/Gitonomy/Git/Blob.php
@@ -19,6 +19,9 @@ namespace Gitonomy\Git;
  */
 class Blob
 {
+    /**
+     * @var int Size that git uses to look for NULL byte: https://git.kernel.org/pub/scm/git/git.git/tree/xdiff-interface.c?h=v2.44.0#n193
+     */
     private const FIRST_FEW_BYTES = 8000;
 
     /**
@@ -96,6 +99,9 @@ class Blob
     /**
      * Determines if file is binary.
      *
+     * Uses the same check that git uses to determine if a file is binary or not
+     * https://git.kernel.org/pub/scm/git/git.git/tree/xdiff-interface.c?h=v2.44.0#n193
+     *
      * @return bool
      */
     public function isBinary()
@@ -105,6 +111,9 @@ class Blob
 
     /**
      * Determines if file is text.
+     *
+     * Uses the same check that git uses to determine if a file is binary or not
+     * https://git.kernel.org/pub/scm/git/git.git/tree/xdiff-interface.c?h=v2.44.0#n193
      *
      * @return bool
      */

--- a/tests/Gitonomy/Git/Tests/BlobTest.php
+++ b/tests/Gitonomy/Git/Tests/BlobTest.php
@@ -23,6 +23,11 @@ class BlobTest extends AbstractTest
         return $repository->getCommit(self::LONGFILE_COMMIT)->getTree()->resolvePath('README.md');
     }
 
+    public function getImageBlob($repository)
+    {
+        return $repository->getCommit(self::LONGFILE_COMMIT)->getTree()->resolvePath('image.jpg');
+    }
+
     /**
      * @dataProvider provideFoobar
      */
@@ -67,8 +72,10 @@ class BlobTest extends AbstractTest
      */
     public function testIsText($repository)
     {
-        $blob = $this->getReadmeBlob($repository);
-        $this->assertTrue($blob->isText());
+        $readmeBlob = $this->getReadmeBlob($repository);
+        $this->assertTrue($readmeBlob->isText());
+        $imageBlob = $this->getImageBlob($repository);
+        $this->assertFalse($imageBlob->isText());
     }
 
     /**
@@ -76,7 +83,9 @@ class BlobTest extends AbstractTest
      */
     public function testIsBinary($repository)
     {
-        $blob = $this->getReadmeBlob($repository);
-        $this->assertFalse($blob->isBinary());
+        $readmeBlob = $this->getReadmeBlob($repository);
+        $this->assertFalse($readmeBlob->isBinary());
+        $imageBlob = $this->getImageBlob($repository);
+        $this->assertTrue($imageBlob->isBinary());
     }
 }


### PR DESCRIPTION
First wanted to implement this through the use of `git ls-files --eol` but this would require you to know the tree, which is not always known.

[This comment](https://stackoverflow.com/a/6134127) on stack overflow pointed to the implementation git uses:
https://git.kernel.org/pub/scm/git/git.git/tree/xdiff-interface.c?h=v2.30.0#n187 

[latest version](https://git.kernel.org/pub/scm/git/git.git/tree/xdiff-interface.c?h=v2.40.1#n192) is unchanged

Closes #218