### PR TITLE
Update tests for new git version

### DIFF
--- a/tests/Gitonomy/Git/Tests/RepositoryTest.php
+++ b/tests/Gitonomy/Git/Tests/RepositoryTest.php
@@ -43,8 +43,8 @@ class RepositoryTest extends AbstractTest
     public function testGetSize($repository)
     {
         $size = $repository->getSize();
-        $this->assertGreaterThanOrEqual(53, $size, 'Repository is at least 53KB');
-        $this->assertLessThan(80, $size, 'Repository is less than 80KB');
+        $this->assertGreaterThanOrEqual(57, $size, 'Repository is at least 57KB');
+        $this->assertLessThan(84, $size, 'Repository is less than 84KB');
     }
 
     public function testIsBare()


### PR DESCRIPTION
When cloning a project with git 2.43.2 some more files are added that increase the size of the repository, invalidating the size test.

on such file is a `pack-*.rev file` added in 2.41.0 https://github.blog/2023-06-01-highlights-from-git-2-41/#on-disk-reverse-indexes-by-default

Another one is `sendemail-validate.sample`, but could not quickly find in what version it was introduced.

There have also been some other  updates to files to make them larger.

In total the difference between git version 2.40.1 and 2.43.2 is 4028 bytes.

I have updated the tests to increase the size by 4 kb, also for the minimum size as with new git versions it does not seems to be close to this number.

Size diff:
```diff
@@ -1,7 +1,8 @@
-git version 2.40.1
+git version 2.43.2
 
 .git/objects/pack/pack-646f69826eb454b74c466756d98d499a57e881b8.pack:40247
 .git/objects/pack/pack-646f69826eb454b74c466756d98d499a57e881b8.idx:11656
+.git/objects/pack/pack-646f69826eb454b74c466756d98d499a57e881b8.rev:1564
 .git/refs/remotes/origin/HEAD:32
 .git/refs/heads/master:41
 .git/index:1002
@@ -9,13 +10,13 @@
 .git/config:243
 .git/packed-refs:568
 .git/HEAD:23
-.git/logs/refs/remotes/origin/HEAD:161
-.git/logs/refs/heads/master:161
-.git/logs/HEAD:161
+.git/logs/refs/remotes/origin/HEAD:211
+.git/logs/refs/heads/master:211
+.git/logs/HEAD:211
 .git/info/exclude:240
 .git/hooks/pre-receive.sample:544
 .git/hooks/fsmonitor-watchman.sample:4726
-.git/hooks/pre-commit.sample:1643
+.git/hooks/pre-commit.sample:1649
 .git/hooks/commit-msg.sample:896
 .git/hooks/pre-applypatch.sample:424
 .git/hooks/pre-rebase.sample:4898
@@ -26,3 +27,4 @@
 .git/hooks/push-to-checkout.sample:2783
 .git/hooks/applypatch-msg.sample:478
 .git/hooks/update.sample:3650
+.git/hooks/sendemail-validate.sample:2308
```