### PR TITLE
Multiple small fixes

### DIFF
--- a/src/Gitonomy/Git/Commit.php
+++ b/src/Gitonomy/Git/Commit.php
@@ -380,9 +380,9 @@ class Commit extends Revision
             array_shift($lines);
             array_shift($lines);
 
-            $data['bodyMessage'] = implode("\n", $lines);
+            $this->data['bodyMessage'] = implode("\n", $lines);
 
-            return $data['bodyMessage'];
+            return $this->data['bodyMessage'];
         }
 
         $parser = new Parser\CommitParser();

--- a/src/Gitonomy/Git/Parser/CommitParser.php
+++ b/src/Gitonomy/Git/Parser/CommitParser.php
@@ -44,8 +44,8 @@ class CommitParser extends ParserBase
         $this->consumeNewLine();
 
         $this->consume('committer ');
-        list($this->committerName, $this->committerEmail, $this->committerDate) = $this->consumeNameEmailDate();
-        $this->committerDate = $this->parseDate($this->committerDate);
+        list($this->committerName, $this->committerEmail, $committerDate) = $this->consumeNameEmailDate();
+        $this->committerDate = $this->parseDate($committerDate);
 
         // will consume an GPG signed commit if there is one
         $this->consumeGPGSignature();

--- a/src/Gitonomy/Git/Parser/LogParser.php
+++ b/src/Gitonomy/Git/Parser/LogParser.php
@@ -37,13 +37,13 @@ class LogParser extends CommitParser
             }
 
             $this->consume('author ');
-            list($commit['authorName'], $commit['authorEmail'], $commit['authorDate']) = $this->consumeNameEmailDate();
-            $commit['authorDate'] = $this->parseDate($commit['authorDate']);
+            list($commit['authorName'], $commit['authorEmail'], $authorDate) = $this->consumeNameEmailDate();
+            $commit['authorDate'] = $this->parseDate($authorDate);
             $this->consumeNewLine();
 
             $this->consume('committer ');
-            list($commit['committerName'], $commit['committerEmail'], $commit['committerDate']) = $this->consumeNameEmailDate();
-            $commit['committerDate'] = $this->parseDate($commit['committerDate']);
+            list($commit['committerName'], $commit['committerEmail'], $committerDate) = $this->consumeNameEmailDate();
+            $commit['committerDate'] = $this->parseDate($committerDate);
 
             // will consume an GPG signed commit if there is one
             $this->consumeGPGSignature();

--- a/src/Gitonomy/Git/Parser/TagParser.php
+++ b/src/Gitonomy/Git/Parser/TagParser.php
@@ -40,8 +40,8 @@ class TagParser extends ParserBase
         $this->consumeNewLine();
 
         $this->consume('tagger ');
-        list($this->taggerName, $this->taggerEmail, $this->taggerDate) = $this->consumeNameEmailDate();
-        $this->taggerDate = $this->parseDate($this->taggerDate);
+        list($this->taggerName, $this->taggerEmail, $taggerDate) = $this->consumeNameEmailDate();
+        $this->taggerDate = $this->parseDate($taggerDate);
 
         $this->consumeNewLine();
         $this->consumeNewLine();

--- a/src/Gitonomy/Git/Reference/Tag.php
+++ b/src/Gitonomy/Git/Reference/Tag.php
@@ -191,9 +191,9 @@ class Tag extends Reference
             array_shift($lines);
             array_pop($lines);
 
-            $data['bodyMessage'] = implode("\n", $lines);
+            $this->data['bodyMessage'] = implode("\n", $lines);
 
-            return $data['bodyMessage'];
+            return $this->data['bodyMessage'];
         }
 
         $parser = new TagParser();

--- a/src/Gitonomy/Git/ReferenceBag.php
+++ b/src/Gitonomy/Git/ReferenceBag.php
@@ -354,11 +354,7 @@ class ReferenceBag implements \Countable, \IteratorAggregate
             $parser = new Parser\ReferenceParser();
             $output = $this->repository->run('show-ref');
         } catch (RuntimeException $e) {
-            $output = $e->getOutput();
-            $error = $e->getErrorOutput();
-            if ($error) {
-                throw new RuntimeException('Error while getting list of references: '.$error);
-            }
+            $output = null;
         }
         $parser->parse($output);
 


### PR DESCRIPTION
## Fix computed data not assigned to cache
In `Commit.php` and `Tag.php` the computed value is stored in the class variable `$data` but in a (non existing) local `$data` variable. Causing recompute when the function is called again.

## Fix assigning two data types to the same variable
In `CommitParser.php`, `LogParser.php` and `TagParser.php` a function is called to get the date as a string and assigned to the class variable, only to be parsed as a `\DateTime` a line later and assigned to the same variable.

Solution used here to to create a temporary variable and parse that as a sate to avoid the class variable being two types.

## Fix calling of removed functions that would just return null
In `ReferenceBag.php` the `initialize` has an try around run and the catch expect functions to be available on `RuntimeException` that where removed and just return null.

This seems to be behavior that is now expected. So if it throws an error a null is used instead of using functions that do not exists.

**Please double check this last one**. It resembles the what is currently happening, but do not know you want to change this.