### PR TITLE
Fix incorrect file name on new or deleted empty files

### DIFF
--- a/src/Gitonomy/Git/Parser/DiffParser.php
+++ b/src/Gitonomy/Git/Parser/DiffParser.php
@@ -38,6 +38,7 @@ class DiffParser extends ParserBase
                 $newMode = $this->consumeTo("\n");
                 $this->consumeNewLine();
                 $oldMode = null;
+                $oldName = '/dev/null';
             }
             if ($this->expects('old mode ')) {
                 $oldMode = $this->consumeTo("\n");
@@ -49,6 +50,7 @@ class DiffParser extends ParserBase
             if ($this->expects('deleted file mode ')) {
                 $oldMode = $this->consumeTo("\n");
                 $newMode = null;
+                $newName = '/dev/null';
                 $this->consumeNewLine();
             }
 

--- a/tests/Gitonomy/Git/Tests/DiffTest.php
+++ b/tests/Gitonomy/Git/Tests/DiffTest.php
@@ -150,4 +150,26 @@ class DiffTest extends AbstractTest
         $files = $repository->getCommit(self::FILE_WITH_UMLAUTS_COMMIT)->getDiff()->getFiles();
         $this->assertSame('file_with_umlauts_\303\244\303\266\303\274', $files[0]->getNewName());
     }
+
+    public function testEmptyNewFile()
+    {
+        $diff = Diff::parse("diff --git a/test b/test\nnew file mode 100644\nindex 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\n");
+        $firstFile = $diff->getFiles()[0];
+
+        $this->assertTrue($firstFile->isCreation());
+        $this->assertFalse($firstFile->isDeletion());
+        $this->assertSame('test', $firstFile->getNewName());
+        $this->assertNull($firstFile->getOldName());
+    }
+
+    public function testEmptyOldFile()
+    {
+        $diff = Diff::parse("diff --git a/test b/test\ndeleted file mode 100644\nindex e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..0000000000000000000000000000000000000000\n");
+        $firstFile = $diff->getFiles()[0];
+
+        $this->assertFalse($firstFile->isCreation());
+        $this->assertTrue($firstFile->isDeletion());
+        $this->assertNull($firstFile->getNewName());
+        $this->assertSame('test', $firstFile->getOldName());
+    }
 }


### PR DESCRIPTION
The diff parser incorrectly parsed the below two diff patches

New file:
```diff
diff --git a/test b/test
new file mode 100644
index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
```

Deleted file:
```diff
diff --git a/test b/test
deleted file mode 100644
index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..0000000000000000000000000000000000000000
```

As the diff file would incorrectly leave the newName/oldName in the diff fille. Breaking the `isCreation()`, `isDeletion()` and related functions as it would still contain a file name.

This PR fixes this by setting the file name to `/dev/null` when it is a new/deleted file.