### PR TITLE
fix error with empty index by including raw information in diff

### DIFF
--- a/src/Gitonomy/Git/Commit.php
+++ b/src/Gitonomy/Git/Commit.php
@@ -62,7 +62,7 @@ class Commit extends Revision
      */
     public function getDiff()
     {
-        $args = ['-r', '-p', '-m', '-M', '--no-commit-id', '--full-index', $this->revision];
+        $args = ['-r', '-p', '--raw', '-m', '-M', '--no-commit-id', '--full-index', $this->revision];
 
         $diff = Diff::parse($this->repository->run('diff-tree', $args));
         $diff->setRepository($this->repository);

--- a/src/Gitonomy/Git/Diff/File.php
+++ b/src/Gitonomy/Git/Diff/File.php
@@ -278,6 +278,10 @@ class File
             throw new \LogicException('Can\'t return old Blob on a creation');
         }
 
+        if ($this->oldIndex === '') {
+            throw new \RuntimeException('Index is missing to return Blob object.');
+        }
+
         return $this->repository->getBlob($this->oldIndex);
     }
 
@@ -289,6 +293,10 @@ class File
 
         if ($this->isDeletion()) {
             throw new \LogicException('Can\'t return new Blob on a deletion');
+        }
+
+        if ($this->newIndex === '') {
+            throw new \RuntimeException('Index is missing to return Blob object.');
         }
 
         return $this->repository->getBlob($this->newIndex);

--- a/src/Gitonomy/Git/Repository.php
+++ b/src/Gitonomy/Git/Repository.php
@@ -416,7 +416,7 @@ class Repository
             $revisions = new RevisionList($this, $revisions);
         }
 
-        $args = array_merge(['-r', '-p', '-m', '-M', '--no-commit-id', '--full-index'], $revisions->getAsTextArray());
+        $args = array_merge(['-r', '-p', '--raw', '-m', '-M', '--no-commit-id', '--full-index'], $revisions->getAsTextArray());
 
         $diff = Diff::parse($this->run('diff', $args));
         $diff->setRepository($this);

--- a/src/Gitonomy/Git/WorkingCopy.php
+++ b/src/Gitonomy/Git/WorkingCopy.php
@@ -50,7 +50,7 @@ class WorkingCopy
 
     public function getDiffPending()
     {
-        $diff = Diff::parse($this->run('diff', ['-r', '-p', '-m', '-M', '--full-index']));
+        $diff = Diff::parse($this->run('diff', ['-r', '-p', '--raw', '-m', '-M', '--full-index']));
         $diff->setRepository($this->repository);
 
         return $diff;
@@ -58,7 +58,7 @@ class WorkingCopy
 
     public function getDiffStaged()
     {
-        $diff = Diff::parse($this->run('diff', ['-r', '-p', '-m', '-M', '--full-index', '--staged']));
+        $diff = Diff::parse($this->run('diff', ['-r', '-p', '--raw', '-m', '-M', '--full-index', '--staged']));
         $diff->setRepository($this->repository);
 
         return $diff;

--- a/tests/Gitonomy/Git/Tests/DiffTest.php
+++ b/tests/Gitonomy/Git/Tests/DiffTest.php
@@ -13,6 +13,8 @@
 namespace Gitonomy\Git\Tests;
 
 use Gitonomy\Git\Diff\Diff;
+use Gitonomy\Git\Diff\File;
+use Gitonomy\Git\Repository;
 
 class DiffTest extends AbstractTest
 {
@@ -149,5 +151,111 @@ class DiffTest extends AbstractTest
     {
         $files = $repository->getCommit(self::FILE_WITH_UMLAUTS_COMMIT)->getDiff()->getFiles();
         $this->assertSame('file_with_umlauts_\303\244\303\266\303\274', $files[0]->getNewName());
+    }
+
+    public function testDeleteFileWithoutRaw()
+    {
+        $deprecationCalled = false;
+        $self = $this;
+        set_error_handler(function (int $errno, string $errstr) use ($self, &$deprecationCalled): void {
+            $deprecationCalled = true;
+            $self->assertSame('Using Diff::parse without raw information is deprecated. See https://github.com/gitonomy/gitlib/issues/227.', $errstr);
+        }, E_USER_DEPRECATED);
+
+        $diff = Diff::parse(<<<'DIFF'
+        diff --git a/test b/test
+        deleted file mode 100644
+        index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..0000000000000000000000000000000000000000
+
+        DIFF);
+        $firstFile = $diff->getFiles()[0];
+
+        restore_exception_handler();
+
+        $this->assertTrue($deprecationCalled);
+        $this->assertFalse($firstFile->isCreation());
+        // TODO: Enable after #226 is merged
+        //$this->assertTrue($firstFile->isDeletion());
+        //$this->assertFalse($firstFile->isChangeMode());
+        $this->assertSame('e69de29bb2d1d6434b8b29ae775ad8c2e48c5391', $firstFile->getOldIndex());
+        $this->assertNull($firstFile->getNewIndex());
+    }
+
+    public function testModeChangeFileWithoutRaw()
+    {
+        $deprecationCalled = false;
+        $self = $this;
+        set_error_handler(function (int $errno, string $errstr) use ($self, &$deprecationCalled): void {
+            $deprecationCalled = true;
+            $self->assertSame('Using Diff::parse without raw information is deprecated. See https://github.com/gitonomy/gitlib/issues/227.', $errstr);
+        }, E_USER_DEPRECATED);
+
+        $diff = Diff::parse(<<<'DIFF'
+        diff --git a/a.out b/a.out
+        old mode 100755
+        new mode 100644
+
+        DIFF);
+        $firstFile = $diff->getFiles()[0];
+
+        restore_exception_handler();
+
+        $this->assertTrue($deprecationCalled);
+        $this->assertFalse($firstFile->isCreation());
+        $this->assertFalse($firstFile->isDeletion());
+        $this->assertTrue($firstFile->isChangeMode());
+        $this->assertSame('', $firstFile->getOldIndex());
+        $this->assertSame('', $firstFile->getNewIndex());
+    }
+
+    public function testModeChangeFileWithRaw()
+    {
+        $deprecationCalled = false;
+        set_error_handler(function (int $errno, string $errstr) use (&$deprecationCalled): void {
+            $deprecationCalled = true;
+        }, E_USER_DEPRECATED);
+
+        $diff = Diff::parse(<<<'DIFF'
+        :100755 100644 d1af4b23d0cc9313e5b2d3ef2fb9696c94afaa81 d1af4b23d0cc9313e5b2d3ef2fb9696c94afaa81 M      a.out
+
+        diff --git a/a.out b/a.out
+        old mode 100755
+        new mode 100644
+
+        DIFF);
+        $firstFile = $diff->getFiles()[0];
+
+        restore_exception_handler();
+
+        $this->assertFalse($deprecationCalled);
+        $this->assertFalse($firstFile->isCreation());
+        $this->assertFalse($firstFile->isDeletion());
+        $this->assertTrue($firstFile->isChangeMode());
+        $this->assertSame('d1af4b23d0cc9313e5b2d3ef2fb9696c94afaa81', $firstFile->getOldIndex());
+        $this->assertSame('d1af4b23d0cc9313e5b2d3ef2fb9696c94afaa81', $firstFile->getNewIndex());
+    }
+
+    public function testThrowErrorOnBlobGetWithoutIndex()
+    {
+        $repository = $this->getMockBuilder(Repository::class)->disableOriginalConstructor()->getMock();
+        $file = new File('oldName', 'newName', '100755', '100644', '', '', false);
+        $file->setRepository($repository);
+
+        try {
+            $file->getOldBlob();
+        } catch(\RuntimeException $exception) {
+            $this->assertSame('Index is missing to return Blob object.', $exception->getMessage());
+        }
+        try {
+            $file->getNewBlob();
+        } catch(\RuntimeException $exception) {
+            $this->assertSame('Index is missing to return Blob object.', $exception->getMessage());
+        }
+
+        $this->assertFalse($file->isCreation());
+        $this->assertFalse($file->isDeletion());
+        $this->assertTrue($file->isChangeMode());
+        $this->assertSame('', $file->getOldIndex());
+        $this->assertSame('', $file->getNewIndex());
     }
 }


### PR DESCRIPTION
Add raw mode when parsing diffs to always get the index that can be used to get blobs.
Add deprecation notice when getting diff without raw information, but will continue to work as it did before.
Fixes #227 

Would like feedback on the deprecation notice and would like to test against the foobar repository instead of passing in diff manually.