### PR TITLE
Skip third party unsupported headers.

### DIFF
--- a/src/Gitonomy/Git/Parser/LogParser.php
+++ b/src/Gitonomy/Git/Parser/LogParser.php
@@ -88,5 +88,4 @@ class LogParser extends CommitParser
             $this->consumeNewLine();
         }
     }
-
 }

--- a/src/Gitonomy/Git/Parser/LogParser.php
+++ b/src/Gitonomy/Git/Parser/LogParser.php
@@ -51,6 +51,7 @@ class LogParser extends CommitParser
             $this->consumeGPGSignature();
 
             $this->consumeNewLine();
+            $this->consumeUnsupportedLinesToNewLine();
             if ($this->cursor < strlen($this->content)) {
                 $this->consumeNewLine();
             }
@@ -76,4 +77,15 @@ class LogParser extends CommitParser
             $this->log[] = $commit;
         }
     }
+
+    protected function consumeUnsupportedLinesToNewLine() {
+        // Consume any unsupported lines that may appear in the log output. For
+        // example, gitbutler headers or other custom metadata but this should
+        // work regardless of the content.
+        while (!$this->isFinished() && substr($this->content, $this->cursor, 1) !== "\n") {
+            $this->consumeTo("\n");
+            $this->consumeNewLine();
+        }
+    }
+
 }

--- a/src/Gitonomy/Git/Parser/LogParser.php
+++ b/src/Gitonomy/Git/Parser/LogParser.php
@@ -78,7 +78,8 @@ class LogParser extends CommitParser
         }
     }
 
-    protected function consumeUnsupportedLinesToNewLine() {
+    protected function consumeUnsupportedLinesToNewLine()
+    {
         // Consume any unsupported lines that may appear in the log output. For
         // example, gitbutler headers or other custom metadata but this should
         // work regardless of the content.

--- a/tests/Gitonomy/Git/Tests/LogTest.php
+++ b/tests/Gitonomy/Git/Tests/LogTest.php
@@ -12,6 +12,8 @@
 
 namespace Gitonomy\Git\Tests;
 
+use Gitonomy\Git\Parser\LogParser;
+
 class LogTest extends AbstractTest
 {
     /**
@@ -91,4 +93,45 @@ class LogTest extends AbstractTest
         $commits = $repository->getLog()->getCommits();
         $this->assertCount(1, $commits);
     }
+
+    public function testParsesCommitsWithAndWithoutGitButlerHeaders(): void
+    {
+        $logContent = <<<EOT
+  commit 1111111111111111111111111111111111111111
+  tree abcdefabcdefabcdefabcdefabcdefabcdefabcd
+  author John Doe <john@example.com> 1620000000 +0000
+  committer John Doe <john@example.com> 1620000000 +0000
+  
+      First commit message
+  
+  commit 2222222222222222222222222222222222222222
+  tree abcdefabcdefabcdefabcdefabcdefabcdefabcd
+  parent 1111111111111111111111111111111111111111
+  author Jane Smith <jane@example.com> 1620003600 +0000
+  committer Jane Smith <jane@example.com> 1620003600 +0000
+  gitbutler-headers-version: 2
+  gitbutler-change-id: a7bd485c-bae6-45b2-910f-163c78aace81
+  
+      Commit with GitButler headers
+  
+  commit 3333333333333333333333333333333333333333
+  tree abcdefabcdefabcdefabcdefabcdefabcdefabcd
+  author John Doe <john@example.com> 1620007200 +0000
+  committer Jane Smith <jane@example.com> 1620007200 +0000
+  
+      Another commit without GitButler headers
+  
+  EOT;
+
+        $parser = new LogParser();
+        $parser->parse($logContent);
+
+        $log = $parser->log;
+        $this->assertCount(3, $log);
+
+        $this->assertEquals("First commit message\n", $log[0]['message']);
+        $this->assertEquals("Commit with GitButler headers\n", $log[1]['message']);
+        $this->assertEquals("Another commit without GitButler headers\n", $log[2]['message']);
+    }
+
 }

--- a/tests/Gitonomy/Git/Tests/LogTest.php
+++ b/tests/Gitonomy/Git/Tests/LogTest.php
@@ -133,5 +133,4 @@ class LogTest extends AbstractTest
         $this->assertEquals("Commit with GitButler headers\n", $log[1]['message']);
         $this->assertEquals("Another commit without GitButler headers\n", $log[2]['message']);
     }
-
 }

--- a/tests/Gitonomy/Git/Tests/LogTest.php
+++ b/tests/Gitonomy/Git/Tests/LogTest.php
@@ -96,7 +96,7 @@ class LogTest extends AbstractTest
 
     public function testParsesCommitsWithAndWithoutGitButlerHeaders(): void
     {
-        $logContent = <<<EOT
+        $logContent = <<<'EOT'
   commit 1111111111111111111111111111111111111111
   tree abcdefabcdefabcdefabcdefabcdefabcdefabcd
   author John Doe <john@example.com> 1620000000 +0000


### PR DESCRIPTION
We have a problem with some repositories when trying to parse the commit logs of the repository.
Apparently, come of the committers, are using third party tools (https://gitbutler.com/) which tampers with the log and adds additional metadata that might or might not exist before the commit message (might not = not committed with gitbutler).

I have added a method to skip lines until a new line is found in order to accommodate for this.

I have also provided a test (hashes and names are random but it is part of the logs we have encountered) that proves the problem.